### PR TITLE
investigate what conversion to react-intl might look like

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "react-dom": "16.8.6",
     "react-helmet": "5.2.0",
     "react-i18next": "7.13.0",
+    "react-intl": "^4.5.3",
     "react-redux": "6.0.0",
     "react-router-dom": "4.3.1",
     "redux": "4.0.0",

--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -5,7 +5,6 @@ import formatDate from 'date-fns/format';
 import getDate from 'date-fns/get_date';
 import getYear from 'date-fns/get_year';
 import startOfMonth from 'date-fns/start_of_month';
-import i18next from 'i18next';
 import {
   ComputedReportItem,
   getComputedReportItems,
@@ -16,6 +15,7 @@ import {
   ValueFormatter,
 } from 'utils/formatValue';
 import { SortDirection } from 'utils/sort';
+import { t } from '../../i18nProvider';
 
 export interface ChartDatum {
   childName?: string;
@@ -153,7 +153,7 @@ export function getDateRangeString(
 ) {
   const [start, end] = getDateRange(datums, firstOfMonth, lastOfMonth, offset);
 
-  return i18next.t(`chart.date_range`, {
+  return t(`chart.date_range`, {
     count: getDate(end),
     endDate: formatDate(end, 'DD'),
     month: Number(formatDate(start, 'M')) - 1,
@@ -170,10 +170,10 @@ export function getMonthRangeString(
   const [start, end] = getDateRange(datums, true, false, offset);
 
   return [
-    i18next.t(key, {
+    t(key, {
       month: Number(formatDate(start, 'M')) - 1,
     }),
-    i18next.t(key, {
+    t(key, {
       month: Number(formatDate(end, 'M')) - 1,
     }),
   ];
@@ -205,7 +205,7 @@ export function getTooltipContent(formatValue) {
       case 'gb-hours':
       case 'gb-mo':
       case 'vm-hours':
-        return i18next.t(`unit_tooltips.${lookup}`, {
+        return t(`unit_tooltips.${lookup}`, {
           value: `${formatValue(value, unit, options)}`,
         });
       default:
@@ -244,7 +244,7 @@ export function getCostRangeString(
 ) {
   const [start, end] = getDateRange(datums, firstOfMonth, lastOfMonth, offset);
 
-  return i18next.t(key, {
+  return t(key, {
     count: getDate(end),
     endDate: formatDate(end, 'D'),
     month: Number(formatDate(start, 'M')) - 1,

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -17,10 +17,10 @@ import {
   getTooltipLabel,
 } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
-import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryStyleInterface } from 'victory';
+import { t } from '../../i18nProvider';
 import { chartStyles } from './costChart.styles';
 
 interface CostChartProps {
@@ -303,12 +303,12 @@ class CostChart extends React.Component<CostChartProps, State> {
       datum.childName === 'currentCost' ||
       datum.childName === 'previousCost'
     ) {
-      return i18next.t('chart.cost_tooltip', { value });
+      return t('chart.cost_tooltip', { value });
     } else if (
       datum.childName === 'currentInfrastructureCost' ||
       datum.childName === 'previousInfrastructureCost'
     ) {
-      return i18next.t('chart.cost_infrastructure_tooltip', { value });
+      return t('chart.cost_infrastructure_tooltip', { value });
     }
     return value;
   };

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -17,10 +17,10 @@ import {
 } from 'components/charts/common/chartUtils';
 import { getDateRange } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
-import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryStyleInterface } from 'victory';
+import { t } from '../../i18nProvider';
 import { chartStyles, styles } from './historicalCostChart.styles';
 
 interface HistoricalCostChartProps {
@@ -277,12 +277,12 @@ class HistoricalCostChart extends React.Component<
       datum.childName === 'currentCost' ||
       datum.childName === 'previousCost'
     ) {
-      return i18next.t('chart.cost_tooltip', { value });
+      return t('chart.cost_tooltip', { value });
     } else if (
       datum.childName === 'currentInfrastructureCost' ||
       datum.childName === 'previousInfrastructureCost'
     ) {
-      return i18next.t('chart.cost_infrastructure_tooltip', { value });
+      return t('chart.cost_infrastructure_tooltip', { value });
     }
     return value;
   };

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -17,10 +17,10 @@ import {
   getUsageRangeString,
 } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
-import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryStyleInterface } from 'victory';
+import { t } from '../../i18nProvider';
 import { chartStyles, styles } from './historicalUsageChart.styles';
 
 interface HistoricalUsageChartProps {
@@ -343,17 +343,17 @@ class HistoricalUsageChart extends React.Component<
       datum.childName === 'currentLimit' ||
       datum.childName === 'previousLimit'
     ) {
-      return i18next.t('chart.limit_tooltip', { value });
+      return t('chart.limit_tooltip', { value });
     } else if (
       datum.childName === 'currentRequest' ||
       datum.childName === 'previousRequest'
     ) {
-      return i18next.t('chart.requests_tooltip', { value });
+      return t('chart.requests_tooltip', { value });
     } else if (
       datum.childName === 'currentUsage' ||
       datum.childName === 'previousUsage'
     ) {
-      return i18next.t('chart.usage_tooltip', { value });
+      return t('chart.usage_tooltip', { value });
     }
     return value;
   };

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -17,10 +17,10 @@ import {
   getUsageRangeString,
 } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
-import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryStyleInterface } from 'victory';
+import { t } from '../../i18nProvider';
 import { chartStyles } from './usageChart.styles';
 
 interface UsageChartProps {
@@ -309,12 +309,12 @@ class UsageChart extends React.Component<UsageChartProps, State> {
       datum.childName === 'currentRequest' ||
       datum.childName === 'previousRequest'
     ) {
-      return i18next.t('chart.requests_tooltip', { value });
+      return t('chart.requests_tooltip', { value });
     } else if (
       datum.childName === 'currentUsage' ||
       datum.childName === 'previousUsage'
     ) {
-      return i18next.t('chart.usage_tooltip', { value });
+      return t('chart.usage_tooltip', { value });
     }
     return value;
   };

--- a/src/components/filter/filterComposition.tsx
+++ b/src/components/filter/filterComposition.tsx
@@ -6,7 +6,7 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import SelectFilter from './selectFilter';
 
 type FilterKind = 'type' | 'name';
@@ -16,7 +16,7 @@ interface TypeOption {
   value: string;
 }
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   isSingleOption?: boolean;
   options: TypeOption[];
   id: string;
@@ -72,19 +72,19 @@ const FilterCompositionBase: React.SFC<Props> = ({
   switchType,
   onSearch,
   isSingleOption = false,
-  t,
+  intl,
 }) => {
   const filterController =
     name === 'Type' ? (
       <FormSelect
-        aria-label={t('filter.type_aria_label')}
+        aria-label={intl.formatMessage({ id: 'filter.type_aria_label' })}
         value={name}
         onChange={newValue => onSearch({ name, value: newValue })}
       >
         <FormSelectOption
           key={`type-option-empty`}
           value={''}
-          label={t('filter.type_empty')}
+          label={intl.formatMessage({ id: 'filter.type_empty' })}
         />
         {options.map(option => (
           <FormSelectOption
@@ -97,9 +97,12 @@ const FilterCompositionBase: React.SFC<Props> = ({
     ) : (
       <TextInput
         value={value}
-        placeholder={t('source_details.filter.placeholder', {
-          value: name.toLowerCase(),
-        })}
+        placeholder={intl.formatMessage(
+          { id: 'source_details.filter.placeholder' },
+          {
+            value: name.toLowerCase(),
+          }
+        )}
         id={id}
         onChange={newValue => {
           updateFilter({ name, value: newValue });
@@ -123,7 +126,7 @@ const FilterCompositionBase: React.SFC<Props> = ({
               selected={name}
               options={filters.map(filter => ({
                 value: filter,
-                name: t(`filter.${filter}`),
+                name: intl.formatMessage({ id: `filter.${filter}` }),
               }))}
             />
           )}
@@ -134,4 +137,4 @@ const FilterCompositionBase: React.SFC<Props> = ({
   );
 };
 
-export default translate()(FilterCompositionBase);
+export default injectIntl(FilterCompositionBase);

--- a/src/components/filter/filterResults.tsx
+++ b/src/components/filter/filterResults.tsx
@@ -5,9 +5,9 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   onRemoveAll: () => void;
   onRemove: (filter: { name: string; value: string }) => void;
   count: number;
@@ -16,7 +16,7 @@ interface Props extends InjectedTranslateProps {
 
 class FilterResultsBase extends React.Component<Props> {
   public render() {
-    const { t, onRemoveAll, onRemove, count, query } = this.props;
+    const { intl, onRemoveAll, onRemove, count, query } = this.props;
     const filters = Object.keys(query)
       .filter(k => ['Name', 'Type'].includes(k))
       .filter(k => query[k])
@@ -28,13 +28,17 @@ class FilterResultsBase extends React.Component<Props> {
       <>
         <ToolbarGroup>
           <ToolbarItem>
-            <h5>{t('filter.results_count', { count })}</h5>
+            <h5>
+              {intl.formatMessage({ id: 'filter.results_count' }, { count })}
+            </h5>
           </ToolbarItem>
         </ToolbarGroup>
         {filters.length > 0 && (
           <>
             <ToolbarGroup>
-              <ToolbarItem>{t('filter.active_filters')}</ToolbarItem>
+              <ToolbarItem>
+                {intl.formatMessage({ id: 'filter.active_filters' })}
+              </ToolbarItem>
             </ToolbarGroup>
             <ToolbarGroup>
               <ToolbarItem>
@@ -46,7 +50,7 @@ class FilterResultsBase extends React.Component<Props> {
                       onRemove(f);
                     }}
                   >
-                    {t(`filter.${f.name}`)}: {f.value}
+                    {intl.formatMessage({ id: `filter.${f.name}` })}: {f.value}
                   </Chip>
                 ))}
               </ToolbarItem>
@@ -54,7 +58,7 @@ class FilterResultsBase extends React.Component<Props> {
             <ToolbarGroup>
               <ToolbarItem>
                 <Button onClick={onRemoveAll} variant="plain">
-                  {t('filter.results_clear')}
+                  {intl.formatMessage({ id: 'filter.results_clear' })}
                 </Button>
               </ToolbarItem>
             </ToolbarGroup>
@@ -65,4 +69,4 @@ class FilterResultsBase extends React.Component<Props> {
   }
 }
 
-export default translate()(FilterResultsBase);
+export default injectIntl(FilterResultsBase);

--- a/src/components/i18nProvider/i18nProvider.tsx
+++ b/src/components/i18nProvider/i18nProvider.tsx
@@ -1,43 +1,75 @@
-import i18next from 'i18next';
-import XHR from 'i18next-xhr-backend';
+// import i18next from 'i18next';
+// import XHR from 'i18next-xhr-backend';
 import React from 'react';
-import { I18nextProvider, reactI18nextModule } from 'react-i18next';
+import { createIntl, createIntlCache, RawIntlProvider } from 'react-intl';
+import messages_en from '../../locales/en.json';
 
-const appPublicPath =
-  process.env.APP_PUBLIC_PATH || '/insights/platform/cost-management';
+// react-intl does not support nested json, so we need to flatten it
+const flattenMessages = (nestedMessages: any, prefix = '') => {
+  if (nestedMessages === null) {
+    return {};
+  }
+  return Object.keys(nestedMessages).reduce((messages, key) => {
+    const value = nestedMessages[key];
+    const prefixedKey = prefix ? `${prefix}.${key}` : key;
+
+    if (typeof value === 'string') {
+      Object.assign(messages, { [prefixedKey]: value });
+    } else {
+      Object.assign(messages, flattenMessages(value, prefixedKey));
+    }
+
+    return messages;
+  }, {});
+};
+const globalIntlCache = createIntlCache();
+const intl = createIntl(
+  {
+    locale: 'en',
+    messages: flattenMessages(messages_en),
+  },
+  globalIntlCache
+);
+const t = (id: string, value?: any) => intl.formatMessage({ id }, value);
+
+// const appPublicPath =
+//   process.env.APP_PUBLIC_PATH || '/insights/platform/cost-management';
 
 interface Props {
   locale: string;
 }
 
-const initI18n = (language: string) => {
-  return i18next
-    .use(XHR)
-    .use(reactI18nextModule)
-    .init({
-      backend: {
-        loadPath: `${appPublicPath}/locales/{{lng}}.json`,
-      },
-      fallbackLng: 'en',
-      lng: language,
-      ns: ['default'],
-      defaultNS: 'default',
-      react: {
-        wait: true,
-      },
-    });
-};
+// const initI18n = (language: string) => {
+//   return i18next
+//     .use(XHR)
+//     .use(reactI18nextModule)
+//     .init({
+//       backend: {
+//         loadPath: `${appPublicPath}/locales/{{lng}}.json`,
+//       },
+//       fallbackLng: 'en',
+//       lng: language,
+//       ns: ['default'],
+//       defaultNS: 'default',
+//       react: {
+//         wait: true,
+//       },
+//     });
+// };
 
 class I18nProvider extends React.Component<Props> {
-  private i18n = initI18n(this.props.locale);
+  // private i18n = initI18n(this.props.locale);
 
   public render() {
     return (
-      <I18nextProvider i18n={this.i18n as any}>
+      // <I18nextProvider i18n={this.i18n as any}>
+      //   <>{this.props.children}</>
+      // </I18nextProvider>
+      <RawIntlProvider value={intl}>
         <>{this.props.children}</>
-      </I18nextProvider>
+      </RawIntlProvider>
     );
   }
 }
 
-export { I18nProvider };
+export { I18nProvider, globalIntlCache, intl, t };

--- a/src/components/i18nProvider/index.ts
+++ b/src/components/i18nProvider/index.ts
@@ -1,1 +1,1 @@
-export { I18nProvider } from './i18nProvider';
+export { I18nProvider, globalIntlCache, intl, t } from './i18nProvider';

--- a/src/components/reports/reportSummary/reportSummary.tsx
+++ b/src/components/reports/reportSummary/reportSummary.tsx
@@ -10,11 +10,11 @@ import {
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/components/Skeleton';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { FetchStatus } from 'store/common';
 import { styles } from './reportSummary.styles';
 
-interface ReportSummaryProps extends InjectedTranslateProps {
+interface ReportSummaryProps extends WrappedComponentProps {
   children?: React.ReactNode;
   detailsLink?: React.ReactNode;
   status: number;
@@ -28,7 +28,7 @@ const ReportSummaryBase: React.SFC<ReportSummaryProps> = ({
   title,
   subTitle,
   status,
-  t,
+  intl,
 }) => (
   <Card style={styles.reportSummary}>
     <CardHeader>
@@ -51,6 +51,6 @@ const ReportSummaryBase: React.SFC<ReportSummaryProps> = ({
   </Card>
 );
 
-const ReportSummary = translate()(ReportSummaryBase);
+const ReportSummary = injectIntl(ReportSummaryBase);
 
 export { ReportSummary, ReportSummaryProps };

--- a/src/components/reports/reportSummary/reportSummaryAlt.tsx
+++ b/src/components/reports/reportSummary/reportSummaryAlt.tsx
@@ -12,11 +12,11 @@ import {
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/components/Skeleton';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { FetchStatus } from 'store/common';
 import { styles } from './reportSummaryAlt.styles';
 
-interface OcpCloudReportSummaryAltProps extends InjectedTranslateProps {
+interface OcpCloudReportSummaryAltProps extends WrappedComponentProps {
   children?: React.ReactNode;
   detailsLink?: React.ReactNode;
   status: number;
@@ -30,7 +30,7 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
   detailsLink,
   status,
   subTitle,
-  t,
+  intl,
   tabs,
   title,
 }) => (
@@ -75,6 +75,6 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
   </Card>
 );
 
-const ReportSummaryAlt = translate()(OcpCloudReportSummaryAltBase);
+const ReportSummaryAlt = injectIntl(OcpCloudReportSummaryAltBase);
 
 export { ReportSummaryAlt, OcpCloudReportSummaryAltProps };

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -3,7 +3,7 @@ import { Report } from 'api/reports/report';
 import { ComputedReportItemType } from 'components/charts/common/chartUtils';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
   FormatOptions,
@@ -12,7 +12,7 @@ import {
 } from 'utils/formatValue';
 import { styles } from './reportSummaryDetails.styles';
 
-interface ReportSummaryDetailsProps extends InjectedTranslateProps {
+interface ReportSummaryDetailsProps extends WrappedComponentProps {
   chartType?: DashboardChartType;
   computedReportItem?: string;
   computedReportItemValue?: string;
@@ -43,7 +43,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   showTooltip = false,
   showUnits = false,
   showUsageFirst = false,
-  t,
+  intl,
   units,
   usageFormatOptions,
   usageLabel,
@@ -127,10 +127,13 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
       <div style={styles.valueContainer}>
         {Boolean(showTooltip) ? (
           <Tooltip
-            content={t('dashboard.total_cost_tooltip', {
-              infrastructureCost,
-              supplementaryCost,
-            })}
+            content={intl.formatMessage(
+              { id: 'dashboard.total_cost_tooltip' },
+              {
+                infrastructureCost: 'TODO: FIX ME | infrastructureCost',
+                supplementaryCost: 'TODO: FIX ME | supplementaryCost',
+              }
+            )}
             enableFlip
           >
             <div style={styles.value}>{value}</div>
@@ -153,7 +156,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
       ? report.meta.total.request.units
       : '';
     const _units = unitLookupKey(usageUnits);
-    const unitsLabel = t(`units.${_units}`);
+    const unitsLabel = intl.formatMessage({ id: `units.${_units}` });
 
     return (
       <div style={styles.valueContainer}>
@@ -178,7 +181,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
     const usageUnits: string = hasUsage ? report.meta.total.usage.units : '';
     // added as a work-around for azure #1079
     const _units = unitLookupKey(units ? units : usageUnits);
-    const unitsLabel = t(`units.${_units}`);
+    const unitsLabel = intl.formatMessage({ id: `units.${_units}` });
 
     return (
       <div style={styles.valueContainer}>
@@ -236,6 +239,6 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   }
 };
 
-const ReportSummaryDetails = translate()(ReportSummaryDetailsBase);
+const ReportSummaryDetails = injectIntl(ReportSummaryDetailsBase);
 
 export { ReportSummaryDetails, ReportSummaryDetailsProps };

--- a/src/components/reports/reportSummary/reportSummaryItem.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItem.tsx
@@ -1,11 +1,11 @@
 import { Progress, ProgressSize } from '@patternfly/react-core';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { unitLookupKey } from 'utils/formatValue';
 import { reportSummaryItem } from './reportSummaryItem.styles';
 
-interface ReportSummaryItemProps extends InjectedTranslateProps {
+interface ReportSummaryItemProps extends WrappedComponentProps {
   formatValue: ValueFormatter;
   formatOptions?: FormatOptions;
   label: string;
@@ -18,21 +18,27 @@ const ReportSummaryItemBase: React.SFC<ReportSummaryItemProps> = ({
   label,
   formatOptions,
   formatValue,
-  t,
+  intl,
   totalValue,
   units,
   value,
 }) => {
   const lookup = unitLookupKey(units);
-  const unitsLabel = lookup !== 'usd' ? t(`units.${lookup}`) : undefined;
+  const unitsLabel =
+    lookup !== 'usd'
+      ? intl.formatMessage({ id: `units.${lookup}` })
+      : undefined;
 
   const percent = !totalValue ? 0 : (value / totalValue) * 100;
   const percentVal = Number(percent.toFixed(2));
-  const percentLabel = t('percent_of_total', {
-    percent: percentVal,
-    units: unitsLabel,
-    value: formatValue(value, units, formatOptions),
-  });
+  const percentLabel = intl.formatMessage(
+    { id: 'percent_of_total' },
+    {
+      percent: percentVal,
+      units: unitsLabel,
+      value: formatValue(value, units, formatOptions),
+    }
+  );
 
   return (
     <li className={reportSummaryItem}>
@@ -50,6 +56,6 @@ ReportSummaryItemBase.defaultProps = {
   formatValue: v => v,
 };
 
-const ReportSummaryItem = translate()(ReportSummaryItemBase);
+const ReportSummaryItem = injectIntl(ReportSummaryItemBase);
 
 export { ReportSummaryItem, ReportSummaryItemProps };

--- a/src/components/reports/reportSummary/reportSummaryItems.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItems.tsx
@@ -4,7 +4,7 @@ import {
 } from '@redhat-cloud-services/frontend-components/components/Skeleton';
 import { Report, ReportValue } from 'api/reports/report';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { FetchStatus } from 'store/common';
 import {
   ComputedReportItem,
@@ -25,7 +25,7 @@ interface ReportSummaryItemsOwnProps
 }
 
 type ReportSummaryItemsProps = ReportSummaryItemsOwnProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 class ReportSummaryItemsBase extends React.Component<ReportSummaryItemsProps> {
   public shouldComponentUpdate(nextProps: ReportSummaryItemsProps) {
@@ -84,7 +84,7 @@ class ReportSummaryItemsBase extends React.Component<ReportSummaryItemsProps> {
   }
 }
 
-const ReportSummaryItems = translate()(ReportSummaryItemsBase);
+const ReportSummaryItems = injectIntl(ReportSummaryItemsBase);
 
 export {
   ReportSummaryItems,

--- a/src/components/state/emptyFilterState/emptyFilterState.tsx
+++ b/src/components/state/emptyFilterState/emptyFilterState.tsx
@@ -7,10 +7,10 @@ import {
 import { SearchIcon } from '@patternfly/react-icons';
 import { OcpCloudQuery, parseQuery } from 'api/queries/ocpCloudQuery';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { styles } from './emptyFilterState.styles';
 
-interface EmptyFilterStateProps extends InjectedTranslateProps {
+interface EmptyFilterStateProps extends WrappedComponentProps {
   filter?: string;
   icon?: string;
   showMargin?: boolean;
@@ -22,11 +22,11 @@ const EmptyFilterStateBase: React.SFC<EmptyFilterStateProps> = ({
   filter,
   icon = SearchIcon,
   showMargin = true,
-  t,
+  intl,
 
   // destructure last
-  subTitle = t('empty_filter_state.subtitle'),
-  title = t('empty_filter_state.title'),
+  subTitle = intl.formatMessage({ id: 'empty_filter_state.subtitle' }),
+  title = intl.formatMessage({ id: 'empty_filter_state.title' }),
 }) => {
   const getIcon = () => {
     const trim = (val: string) => val.replace(/\s+/g, '').toLowerCase();
@@ -97,6 +97,6 @@ const EmptyFilterStateBase: React.SFC<EmptyFilterStateProps> = ({
   );
 };
 
-const EmptyFilterState = translate()(EmptyFilterStateBase);
+const EmptyFilterState = injectIntl(EmptyFilterStateBase);
 
 export { EmptyFilterState };

--- a/src/components/state/errorState/errorState.tsx
+++ b/src/components/state/errorState/errorState.tsx
@@ -7,10 +7,10 @@ import {
 import { ErrorCircleOIcon, LockIcon } from '@patternfly/react-icons';
 import { AxiosError } from 'axios';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { styles } from './errorState.styles';
 
-interface ErrorStateProps extends InjectedTranslateProps {
+interface ErrorStateProps extends WrappedComponentProps {
   error: AxiosError;
   icon?: string;
 }
@@ -18,10 +18,10 @@ interface ErrorStateProps extends InjectedTranslateProps {
 const ErrorStateBase: React.SFC<ErrorStateProps> = ({
   error,
   icon = ErrorCircleOIcon,
-  t,
+  intl,
 }) => {
-  let title = t('error_state.unexpected_title');
-  let subTitle = t('error_state.unexpected_desc');
+  let title = intl.formatMessage({ id: 'error_state.unexpected_title' });
+  let subTitle = intl.formatMessage({ id: 'error_state.unexpected_desc' });
 
   if (
     error &&
@@ -29,8 +29,8 @@ const ErrorStateBase: React.SFC<ErrorStateProps> = ({
     (error.response.status === 401 || error.response.status === 403)
   ) {
     icon = LockIcon;
-    title = t('error_state.unauthorized_title');
-    subTitle = t('error_state.unauthorized_desc');
+    title = intl.formatMessage({ id: 'error_state.unauthorized_title' });
+    subTitle = intl.formatMessage({ id: 'error_state.unauthorized_desc' });
   }
 
   return (
@@ -44,6 +44,6 @@ const ErrorStateBase: React.SFC<ErrorStateProps> = ({
   );
 };
 
-const ErrorState = translate()(ErrorStateBase);
+const ErrorState = injectIntl(ErrorStateBase);
 
 export { ErrorState };

--- a/src/components/state/loadingState/loadingState.tsx
+++ b/src/components/state/loadingState/loadingState.tsx
@@ -6,19 +6,19 @@ import {
 } from '@patternfly/react-core';
 import { BinocularsIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { styles } from './loadingState.styles';
 
-interface LoadingStateProps extends InjectedTranslateProps {
+interface LoadingStateProps extends WrappedComponentProps {
   icon?: string;
 }
 
 const LoadingStateBase: React.SFC<LoadingStateProps> = ({
   icon = BinocularsIcon,
-  t,
+  intl,
 }) => {
-  const title = t('loading_state.sources_title');
-  const subTitle = t('loading_state.sources_desc');
+  const title = intl.formatMessage({ id: 'loading_state.sources_title' });
+  const subTitle = intl.formatMessage({ id: 'loading_state.sources_desc' });
 
   return (
     <div style={styles.container}>
@@ -31,6 +31,6 @@ const LoadingStateBase: React.SFC<LoadingStateProps> = ({
   );
 };
 
-const LoadingState = translate()(LoadingStateBase);
+const LoadingState = injectIntl(LoadingStateBase);
 
 export { LoadingState };

--- a/src/components/state/maintenanceState/maintenanceState.tsx
+++ b/src/components/state/maintenanceState/maintenanceState.tsx
@@ -6,29 +6,33 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { styles } from './maintenanceState.styles';
 
-type MaintenanceStateOwnProps = InjectedTranslateProps;
+type MaintenanceStateOwnProps = WrappedComponentProps;
 type MaintenanceStateProps = MaintenanceStateOwnProps;
 
 class MaintenanceStateBase extends React.Component<MaintenanceStateProps> {
   public render() {
-    const { t } = this.props;
+    const { intl } = this.props;
 
     return (
       <div style={styles.container}>
         <EmptyState>
           <EmptyStateIcon icon={ExclamationTriangleIcon} />
-          <Title size="lg">{t('maintenance.empty_state_title')}</Title>
-          <EmptyStateBody>{t('maintenance.empty_state_desc')}</EmptyStateBody>
+          <Title size="lg">
+            {intl.formatMessage({ id: 'maintenance.empty_state_title' })}
+          </Title>
+          <EmptyStateBody>
+            {intl.formatMessage({ id: 'maintenance.empty_state_desc' })}
+          </EmptyStateBody>
         </EmptyState>
       </div>
     );
   }
 }
 
-const MaintenanceState = translate()(connect()(MaintenanceStateBase));
+const MaintenanceState = injectIntl(connect()(MaintenanceStateBase));
 
 export { MaintenanceState };

--- a/src/components/state/noProvidersState/noProvidersState.tsx
+++ b/src/components/state/noProvidersState/noProvidersState.tsx
@@ -6,18 +6,18 @@ import {
 } from '@patternfly/react-core';
 import { DollarSignIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { getTestProps, testIds } from 'testIds';
 import { getReleasePath } from 'utils/pathname';
 import { styles } from './noProvidersState.styles';
 
-type NoProvidersStateOwnProps = InjectedTranslateProps;
+type NoProvidersStateOwnProps = WrappedComponentProps;
 type NoProvidersStateProps = NoProvidersStateOwnProps;
 
 class NoProvidersStateBase extends React.Component<NoProvidersStateProps> {
   private getViewSources = () => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const release = getReleasePath();
 
     return (
@@ -25,20 +25,24 @@ class NoProvidersStateBase extends React.Component<NoProvidersStateProps> {
         href={`${release}/settings/sources`}
         {...getTestProps(testIds.providers.view_all_link)}
       >
-        {t('providers.view_sources')}
+        {intl.formatMessage({ id: 'providers.view_sources' })}
       </a>
     );
   };
 
   public render() {
-    const { t } = this.props;
+    const { intl } = this.props;
 
     return (
       <div style={styles.container}>
         <EmptyState>
           <EmptyStateIcon icon={DollarSignIcon} />
-          <Title size="lg">{t('providers.empty_state_title')}</Title>
-          <EmptyStateBody>{t('providers.empty_state_desc')}</EmptyStateBody>
+          <Title size="lg">
+            {intl.formatMessage({ id: 'providers.empty_state_title' })}
+          </Title>
+          <EmptyStateBody>
+            {intl.formatMessage({ id: 'providers.empty_state_desc' })}
+          </EmptyStateBody>
           <div style={styles.viewSources}>{this.getViewSources()}</div>
         </EmptyState>
       </div>
@@ -46,6 +50,6 @@ class NoProvidersStateBase extends React.Component<NoProvidersStateProps> {
   }
 }
 
-const NoProvidersState = translate()(connect()(NoProvidersStateBase));
+const NoProvidersState = injectIntl(connect()(NoProvidersStateBase));
 
 export { NoProvidersState };

--- a/src/pages/costModels/components/addCostModelRateForm.tsx
+++ b/src/pages/costModels/components/addCostModelRateForm.tsx
@@ -10,7 +10,7 @@ import { DollarSignIcon } from '@patternfly/react-icons';
 import { MetricHash } from 'api/metrics';
 import { Option } from 'pages/costModels/components/logic/types';
 import React from 'react';
-import { InjectedTranslateProps } from 'react-i18next';
+import { WrappedComponentProps } from 'react-intl';
 
 export const isRateValid = (rate: string) =>
   (!isNaN(Number(rate)) && Number(rate) > 0) || rate === '';
@@ -104,41 +104,43 @@ const CategorySelector: React.SFC<CategorySelectorProps> = ({
   </FormGroup>
 );
 
-export interface CostTypeSelectorBaseProps extends InjectedTranslateProps {
+export interface CostTypeSelectorBaseProps extends WrappedComponentProps {
   value: string;
   onChange: (value: string) => void;
   costTypes: string[];
 }
 
 export const CostTypeSelectorBase: React.SFC<CostTypeSelectorBaseProps> = ({
-  t,
+  intl,
   value,
   onChange,
   costTypes,
 }) => {
   const options = costTypes.map(costType => ({
     value: costType,
-    label: t(`cost_models.${costType}`),
+    label: intl.formatMessage({ id: `cost_models.${costType}` }),
   }));
 
   const defaultOption = {
     value,
-    label: t(`cost_models.${value}`),
+    label: intl.formatMessage({ id: `cost_models.${value}` }),
   };
   return (
     <CategorySelector
-      label={t('cost_models.add_rate_form.cost_type')}
+      label={intl.formatMessage({ id: 'cost_models.add_rate_form.cost_type' })}
       id={'rate-cost-type-selector'}
       value={value}
       onChange={onChange}
       defaultOption={defaultOption}
       options={options}
-      helperText={<a href="">{t('cost_models.learn_more')}</a>}
+      helperText={
+        <a href="">{intl.formatMessage({ id: 'cost_models.learn_more' })}</a>
+      }
     />
   );
 };
 
-interface SelectorBaseProps extends InjectedTranslateProps {
+interface SelectorBaseProps extends WrappedComponentProps {
   options: Option[];
   onChange: (value: string) => void;
   value: string;
@@ -147,7 +149,7 @@ interface SelectorBaseProps extends InjectedTranslateProps {
 }
 
 export const MetricSelectorBase: React.SFC<SelectorBaseProps> = ({
-  t,
+  intl,
   value,
   onChange,
   isDisabled = false,
@@ -157,12 +159,16 @@ export const MetricSelectorBase: React.SFC<SelectorBaseProps> = ({
   return (
     <CategorySelector
       testId={'metric-selector'}
-      label={t(`cost_models.add_rate_form.metric_select`)}
+      label={intl.formatMessage({
+        id: `cost_models.add_rate_form.metric_select`,
+      })}
       id={'metric-selector'}
       value={value}
       onChange={onChange}
       defaultOption={{
-        label: t('cost_models.add_rate_form.default_option'),
+        label: intl.formatMessage({
+          id: 'cost_models.add_rate_form.default_option',
+        }),
         value: '',
       }}
       options={options}
@@ -173,7 +179,7 @@ export const MetricSelectorBase: React.SFC<SelectorBaseProps> = ({
 };
 
 const MeasurementSelectorBase: React.SFC<SelectorBaseProps> = ({
-  t,
+  intl,
   value,
   onChange,
   isDisabled = false,
@@ -183,12 +189,16 @@ const MeasurementSelectorBase: React.SFC<SelectorBaseProps> = ({
   return (
     <CategorySelector
       testId={'measurement-selector'}
-      label={t(`cost_models.add_rate_form.measurement_select`)}
+      label={intl.formatMessage({
+        id: `cost_models.add_rate_form.measurement_select`,
+      })}
       id={'measurement-selector'}
       value={value}
       onChange={onChange}
       defaultOption={{
-        label: t('cost_models.add_rate_form.default_option'),
+        label: intl.formatMessage({
+          id: 'cost_models.add_rate_form.default_option',
+        }),
         value: '',
       }}
       options={options}
@@ -198,23 +208,25 @@ const MeasurementSelectorBase: React.SFC<SelectorBaseProps> = ({
   );
 };
 
-interface InputBase extends InjectedTranslateProps {
+interface InputBase extends WrappedComponentProps {
   onChange: (value: string) => void;
   value: string;
   isInvalid?: boolean;
 }
 
 const RateInputBase: React.SFC<InputBase> = ({
-  t,
+  intl,
   value,
   onChange,
   isInvalid = false,
 }) => {
   return (
     <FormGroup
-      label={t('cost_models.add_rate_form.rate_input')}
+      label={intl.formatMessage({ id: 'cost_models.add_rate_form.rate_input' })}
       fieldId="rate-input"
-      helperTextInvalid={t('cost_models.add_rate_form.error_message')}
+      helperTextInvalid={intl.formatMessage({
+        id: 'cost_models.add_rate_form.error_message',
+      })}
       isValid={!isInvalid}
     >
       <InputGroup>
@@ -223,7 +235,9 @@ const RateInputBase: React.SFC<InputBase> = ({
         </InputGroupText>
         <TextInput
           type="text"
-          aria-label={t('cost_models.add_rate_form.rate_input')}
+          aria-label={intl.formatMessage({
+            id: 'cost_models.add_rate_form.rate_input',
+          })}
           id="rate-input"
           placeholder="0.00"
           value={value}
@@ -235,7 +249,7 @@ const RateInputBase: React.SFC<InputBase> = ({
   );
 };
 
-export interface AddCostModelRateFormProps extends InjectedTranslateProps {
+export interface AddCostModelRateFormProps extends WrappedComponentProps {
   metric: string;
   setMetric: (value: string) => void;
   measurement: string;
@@ -249,10 +263,10 @@ export interface AddCostModelRateFormProps extends InjectedTranslateProps {
   submit?: () => void;
 }
 
-export const SetMetric = ({ t, onChange, value, options }) => {
+export const SetMetric = ({ intl, onChange, value, options }) => {
   return (
     <MetricSelectorBase
-      t={t}
+      intl={intl}
       onChange={onChange}
       value={value}
       options={options}
@@ -267,18 +281,18 @@ export const SetMeasurement = ({
   measurementChange,
   measurement,
   measurementOptions,
-  t,
+  intl,
 }) => {
   return (
     <>
       <MetricSelectorBase
-        t={t}
+        intl={intl}
         onChange={metricChange}
         value={metric}
         options={metricOptions}
       />
       <MeasurementSelectorBase
-        t={t}
+        intl={intl}
         onChange={measurementChange}
         value={measurement}
         options={measurementOptions}
@@ -301,31 +315,31 @@ export const SetRate = ({
   costTypes,
   costType,
   costTypeChange,
-  t,
+  intl,
 }) => {
   return (
     <>
       <MetricSelectorBase
-        t={t}
+        intl={intl}
         onChange={metricChange}
         value={metric}
         options={metricOptions}
       />
       <MeasurementSelectorBase
-        t={t}
+        intl={intl}
         onChange={measurementChange}
         value={measurement}
         options={measurementOptions}
         isInvalid={isMeasurementInvalid}
       />
       <RateInputBase
-        t={t}
+        intl={intl}
         value={rate}
         onChange={rateChange}
         isInvalid={isRateInvalid}
       />
       <CostTypeSelectorBase
-        t={t}
+        intl={intl}
         costTypes={costTypes}
         value={costType}
         onChange={costTypeChange}

--- a/src/pages/costModels/components/addPriceList.tsx
+++ b/src/pages/costModels/components/addPriceList.tsx
@@ -13,7 +13,7 @@ import {
 import { Metric, MetricHash } from 'api/metrics';
 import { Form } from 'components/forms/form';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect, Omit } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { metricsSelectors } from 'store/metrics';
@@ -241,7 +241,7 @@ export const addRateMachine = Machine<
   }
 );
 
-interface AddPriceListBaseProps extends InjectedTranslateProps {
+interface AddPriceListBaseProps extends WrappedComponentProps {
   costTypes: string[];
   metricsHash: MetricHash;
   submitRate: (data: SubmitPayload) => void;
@@ -284,7 +284,7 @@ export class AddPriceListBase extends React.Component<
         context: { metric, measurement, rate, costType },
       },
     } = this.state;
-    const { t, items, metricsHash, costTypes } = this.props;
+    const { intl, items, metricsHash, costTypes } = this.props;
     const { send } = this.service;
     const stateNames = this.state.current.toStrings();
     const mainState = stateNames.length > 1 ? stateNames[1] : stateNames[0];
@@ -295,9 +295,9 @@ export class AddPriceListBase extends React.Component<
       case 'setMetric':
         return (
           <SetMetric
-            t={t}
+            intl={intl}
             options={Object.keys(availableRates).map(r => ({
-              label: t(`cost_models.${r}`),
+              label: intl.formatMessage({ id: `cost_models.${r}` }),
               value: r,
             }))}
             onChange={(value: string) =>
@@ -309,9 +309,9 @@ export class AddPriceListBase extends React.Component<
       case 'setMeasurement':
         return (
           <SetMeasurement
-            t={t}
+            intl={intl}
             metricOptions={Object.keys(availableRates).map(r => ({
-              label: t(`cost_models.${r}`),
+              label: intl.formatMessage({ id: `cost_models.${r}` }),
               value: r,
             }))}
             metricChange={(value: string) =>
@@ -319,9 +319,12 @@ export class AddPriceListBase extends React.Component<
             }
             metric={metric}
             measurementOptions={Object.keys(availableRates[metric]).map(m => ({
-              label: t(`cost_models.${m}`, {
-                units: metricsHash[metric][m].label_measurement_unit,
-              }),
+              label: intl.formatMessage(
+                { id: `cost_models.${m}` },
+                {
+                  units: metricsHash[metric][m].label_measurement_unit,
+                }
+              ),
               value: m,
             }))}
             measurement={measurement}
@@ -340,9 +343,9 @@ export class AddPriceListBase extends React.Component<
       case 'setRate.valid':
         return (
           <SetRate
-            t={t}
+            intl={intl}
             metricOptions={Object.keys(availableRates).map(r => ({
-              label: t(`cost_models.${r}`),
+              label: intl.formatMessage({ id: `cost_models.${r}` }),
               value: r,
             }))}
             metricChange={(value: string) =>
@@ -351,9 +354,12 @@ export class AddPriceListBase extends React.Component<
             metric={metric}
             measurement={measurement}
             measurementOptions={Object.keys(availableRates[metric]).map(m => ({
-              label: t(`cost_models.${m}`, {
-                units: metricsHash[metric][m].label_measurement_unit,
-              }),
+              label: intl.formatMessage(
+                { id: `cost_models.${m}` },
+                {
+                  units: metricsHash[metric][m].label_measurement_unit,
+                }
+              ),
               value: m,
             }))}
             measurementChange={(value: string) =>
@@ -382,9 +388,9 @@ export class AddPriceListBase extends React.Component<
         return (
           <>
             <SetRate
-              t={t}
+              intl={intl}
               metricOptions={Object.keys(availableRates).map(r => ({
-                label: t(`cost_models.${r}`),
+                label: intl.formatMessage({ id: `cost_models.${r}` }),
                 value: r,
               }))}
               metricChange={(value: string) =>
@@ -393,9 +399,12 @@ export class AddPriceListBase extends React.Component<
               metric={metric}
               measurementOptions={Object.keys(availableRates[metric]).map(
                 m => ({
-                  label: t(`cost_models.${m}`, {
-                    units: metricsHash[metric][m].label_measurement_unit,
-                  }),
+                  label: intl.formatMessage(
+                    { id: `cost_models.${m}` },
+                    {
+                      units: metricsHash[metric][m].label_measurement_unit,
+                    }
+                  ),
                   value: m,
                 })
               )}
@@ -432,7 +441,7 @@ export class AddPriceListBase extends React.Component<
   }
 
   public renderActions() {
-    const { t, metricsHash, submitRate, cancel } = this.props;
+    const { intl, metricsHash, submitRate, cancel } = this.props;
     const {
       current,
       current: {
@@ -456,10 +465,12 @@ export class AddPriceListBase extends React.Component<
               })
             }
           >
-            {t('cost_models_wizard.price_list.add_rate')}
+            {intl.formatMessage({
+              id: 'cost_models_wizard.price_list.add_rate',
+            })}
           </Button>
           <Button variant={ButtonVariant.link} onClick={cancel}>
-            {t('cost_models_wizard.price_list.cancel')}
+            {intl.formatMessage({ id: 'cost_models_wizard.price_list.cancel' })}
           </Button>
         </ActionGroup>
       );
@@ -471,29 +482,31 @@ export class AddPriceListBase extends React.Component<
           variant={ButtonVariant.primary}
           isDisabled
         >
-          {t('cost_models_wizard.price_list.add_rate')}
+          {intl.formatMessage({ id: 'cost_models_wizard.price_list.add_rate' })}
         </Button>
         <Button variant={ButtonVariant.link} onClick={cancel}>
-          {t('cost_models_wizard.price_list.cancel')}
+          {intl.formatMessage({ id: 'cost_models_wizard.price_list.cancel' })}
         </Button>
       </ActionGroup>
     );
   }
 
   public render() {
-    const { t } = this.props;
+    const { intl } = this.props;
 
     return (
       <Stack gutter="md">
         <StackItem>
           <Title size={TitleSize.xl}>
-            {t('cost_models_wizard.price_list.title')}
+            {intl.formatMessage({ id: 'cost_models_wizard.price_list.title' })}
           </Title>
         </StackItem>
         <StackItem>
           <TextContent>
             <Text component={TextVariants.h6}>
-              {t('cost_models_wizard.price_list.sub_title_add')}
+              {intl.formatMessage({
+                id: 'cost_models_wizard.price_list.sub_title_add',
+              })}
             </Text>
           </TextContent>
         </StackItem>
@@ -510,4 +523,4 @@ export default connect(
   createMapStateToProps(state => ({
     costTypes: metricsSelectors.costTypes(state),
   }))
-)(translate()(AddPriceListBase));
+)(injectIntl(AddPriceListBase));

--- a/src/pages/costModels/components/costModelRateItem.tsx
+++ b/src/pages/costModels/components/costModelRateItem.tsx
@@ -8,10 +8,10 @@ import {
   TitleSize,
 } from '@patternfly/react-core';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { formatCurrency } from 'utils/rateCurrency';
 
-export interface CostModelRateItemProps extends InjectedTranslateProps {
+export interface CostModelRateItemProps extends WrappedComponentProps {
   index: number;
   units: string;
   metric: string;
@@ -21,7 +21,7 @@ export interface CostModelRateItemProps extends InjectedTranslateProps {
 }
 
 const CostModelRateItemBase: React.SFC<CostModelRateItemProps> = ({
-  t,
+  intl,
   index,
   units,
   metric,
@@ -29,7 +29,7 @@ const CostModelRateItemBase: React.SFC<CostModelRateItemProps> = ({
   rate,
   actionComponent,
 }) => {
-  const unitsLabel = t(`cost_models.${units}`);
+  const unitsLabel = intl.formatMessage({ id: `cost_models.${units}` });
   return (
     <DataListItem aria-labelledby={`rate-${index}`}>
       <DataListItemRow>
@@ -37,16 +37,22 @@ const CostModelRateItemBase: React.SFC<CostModelRateItemProps> = ({
           dataListCells={[
             <DataListCell key={`rate-data`}>
               <Title size={TitleSize.lg}>
-                {t(`cost_models.${metric}`)}{' '}
-                {t(`cost_models.lowercase.${measurement}`, {
-                  units: unitsLabel,
-                })}
+                {intl.formatMessage({ id: `cost_models.${metric}` })} }
+                {intl.formatMessage(
+                  { id: `cost_models.lowercase.${measurement}` },
+                  {
+                    units: unitsLabel,
+                  }
+                )}
               </Title>
               <Title size={TitleSize.md}>
-                {t(`cost_models.for_every`, {
-                  units: unitsLabel,
-                  rate: formatCurrency(Number(rate)),
-                })}
+                {intl.formatMessage(
+                  { id: `cost_models.for_every` },
+                  {
+                    units: unitsLabel,
+                    rate: formatCurrency(Number(rate)),
+                  }
+                )}
               </Title>
             </DataListCell>,
           ]}
@@ -65,4 +71,4 @@ const CostModelRateItemBase: React.SFC<CostModelRateItemProps> = ({
   );
 };
 
-export default translate()(CostModelRateItemBase);
+export default injectIntl(CostModelRateItemBase);

--- a/src/pages/costModels/components/rateTable.tsx
+++ b/src/pages/costModels/components/rateTable.tsx
@@ -6,18 +6,18 @@ import {
   TableVariant,
 } from '@patternfly/react-table';
 import React from 'react';
-import { InjectedTranslateProps } from 'react-i18next';
+import { WrappedComponentProps } from 'react-intl';
 import { formatCurrency } from 'utils/formatValue';
 import { TierData } from './addPriceList';
 
-interface RateTableProps extends InjectedTranslateProps {
+interface RateTableProps extends WrappedComponentProps {
   tiers: TierData[];
   actions?: IActions;
   isCompact?: boolean;
 }
 
 export const RateTable: React.SFC<RateTableProps> = ({
-  t,
+  intl,
   tiers,
   actions,
   isCompact,
@@ -27,18 +27,21 @@ export const RateTable: React.SFC<RateTableProps> = ({
       aria-label="price-list"
       variant={isCompact ? TableVariant.compact : undefined}
       rows={tiers.map(tier => [
-        t(`cost_models.${tier.meta.label_metric}`),
-        t(`cost_models.${tier.meta.label_measurement}`, {
-          units: tier.meta.label_measurement_unit,
-        }),
+        intl.formatMessage({ id: `cost_models.${tier.meta.label_metric}` }),
+        intl.formatMessage(
+          { id: `cost_models.${tier.meta.label_measurement}` },
+          {
+            units: tier.meta.label_measurement_unit,
+          }
+        ),
         `${formatCurrency(Number(tier.rate))}`,
         tier.costType,
       ])}
       cells={[
-        t('cost_models.table.metric'),
-        t('cost_models.table.measurement'),
-        t('cost_models.table.rate'),
-        t('cost_models.table.cost_type'),
+        intl.formatMessage({ id: 'cost_models.table.metric' }),
+        intl.formatMessage({ id: 'cost_models.table.measurement' }),
+        intl.formatMessage({ id: 'cost_models.table.rate' }),
+        intl.formatMessage({ id: 'cost_models.table.cost_type' }),
       ]}
       actions={actions}
     >

--- a/src/pages/costModels/costModelsDetails/addSourceStep.tsx
+++ b/src/pages/costModels/costModelsDetails/addSourceStep.tsx
@@ -17,13 +17,13 @@ import {
 } from 'pages/costModels/components/filterLogic';
 import { WarningIcon } from 'pages/costModels/components/warningIcon';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { sourcesActions, sourcesSelectors } from 'store/sourceSettings';
 import { AssignSourcesToolbar } from './assignSourcesModalToolbar';
 
-interface AddSourcesStepProps extends InjectedTranslateProps {
+interface AddSourcesStepProps extends WrappedComponentProps {
   providers: Provider[];
   isLoadingSources: boolean;
   fetchingSourcesError: string;
@@ -57,7 +57,9 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
         : false;
       const provCostModels =
         providerData.cost_models === undefined
-          ? this.props.t('cost_models_wizard.source_table.default_cost_model')
+          ? this.props.intl.formatMessage({
+              id: 'cost_models_wizard.source_table.default_cost_model',
+            })
           : providerData.cost_models.map(cm => cm.name).join(',');
       const warningIcon =
         isSelected &&
@@ -66,9 +68,12 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
           undefined ? (
           <WarningIcon
             key={providerData.uuid}
-            text={this.props.t('cost_models_wizard.warning_override_source', {
-              cost_model: provCostModels,
-            })}
+            text={this.props.intl.formatMessage(
+              { id: 'cost_models_wizard.warning_override_source' },
+              {
+                cost_model: provCostModels,
+              }
+            )}
           />
         ) : null;
       const cellName = (
@@ -80,7 +85,9 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
         cells: [
           cellName,
           provCostModels ||
-            this.props.t('cost_models_wizard.source_table.default_cost_model'),
+            this.props.intl.formatMessage({
+              id: 'cost_models_wizard.source_table.default_cost_model',
+            }),
         ],
         selected: isSelected,
       };
@@ -165,7 +172,9 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
         />
         {sources.length > 0 && (
           <Table
-            aria-label={this.props.t('cost_models_details.add_source')}
+            aria-label={this.props.intl.formatMessage({
+              id: 'cost_models_details.add_source',
+            })}
             onSelect={(_evt, isSelected, rowId) => {
               if (rowId === -1) {
                 const newState = this.props.providers.reduce((acc, cur) => {
@@ -190,8 +199,10 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
               });
             }}
             cells={[
-              this.props.t('filter.name'),
-              this.props.t('cost_models_wizard.source_table.column_cost_model'),
+              this.props.intl.formatMessage({ id: 'filter.name' }),
+              this.props.intl.formatMessage({
+                id: 'cost_models_wizard.source_table.column_cost_model',
+              }),
             ]}
             rows={sources}
           >
@@ -201,15 +212,17 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
         )}
         {sources.length === 0 && (
           <EmptyFilterState
-            subTitle={this.props.t('no_match_found_state.desc')}
+            subTitle={this.props.intl.formatMessage({
+              id: 'no_match_found_state.desc',
+            })}
           />
         )}
         <DataToolbar id="costmodels_details.sources_pagination_datatoolbar">
           <DataToolbarContent
             style={{ flexDirection: 'row-reverse' }}
-            aria-label={this.props.t(
-              'cost_models_details.sources_pagination_bottom'
-            )}
+            aria-label={this.props.intl.formatMessage({
+              id: 'cost_models_details.sources_pagination_bottom',
+            })}
           >
             <DataToolbarGroup>
               <DataToolbarItem>
@@ -248,16 +261,18 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
   }
 }
 
-export default connect(
-  createMapStateToProps(state => {
-    return {
-      currentFilter: {
-        name: sourcesSelectors.currentFilterType(state),
-        value: sourcesSelectors.currentFilterValue(state),
-      },
-    };
-  }),
-  {
-    updateFilter: sourcesActions.updateFilterToolbar,
-  }
-)(translate()(AddSourcesStep));
+export default injectIntl(
+  connect(
+    createMapStateToProps(state => {
+      return {
+        currentFilter: {
+          name: sourcesSelectors.currentFilterType(state),
+          value: sourcesSelectors.currentFilterValue(state),
+        },
+      };
+    }),
+    {
+      updateFilter: sourcesActions.updateFilterToolbar,
+    }
+  )(AddSourcesStep)
+);

--- a/src/pages/costModels/costModelsDetails/addSourceWizard.tsx
+++ b/src/pages/costModels/costModelsDetails/addSourceWizard.tsx
@@ -12,7 +12,7 @@ import { CostModel } from 'api/costModels';
 import { Provider } from 'api/providers';
 import { parseApiError } from 'pages/costModels/createCostModelWizard/parseError';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { FetchStatus } from 'store/common';
 import { createMapStateToProps } from 'store/common';
@@ -24,7 +24,7 @@ interface AddSourcesStepState {
   checked: { [uuid: string]: { selected: boolean; meta: Provider } };
 }
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   onClose: () => void;
   onSave: (sources_uuid: string[]) => void;
   isOpen: boolean;
@@ -80,7 +80,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
       onClose,
       isOpen,
       onSave,
-      t,
+      intl,
       costModel,
       updateApiError,
     } = this.props;
@@ -89,9 +89,12 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
         isFooterLeftAligned
         isLarge
         isOpen={isOpen}
-        title={t('cost_models_details.assign_sources', {
-          cost_model: this.props.costModel.name,
-        })}
+        title={intl.formatMessage(
+          { id: 'cost_models_details.assign_sources' },
+          {
+            cost_model: this.props.costModel.name,
+          }
+        )}
         onClose={onClose}
         actions={[
           <Button
@@ -100,7 +103,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
             isDisabled={isUpdateInProgress}
             onClick={onClose}
           >
-            {t('cost_models_wizard.cancel_button')}
+            {intl.formatMessage({ id: 'cost_models_wizard.cancel_button' })}
           </Button>,
           <Button
             key="save"
@@ -113,7 +116,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
               );
             }}
           >
-            {t('cost_models_details.action_assign')}
+            {intl.formatMessage({ id: 'cost_models_details.action_assign' })}
           </Button>,
         ]}
       >
@@ -127,7 +130,9 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
             <Split gutter="md">
               <SplitItem>
                 <Title size="md">
-                  {t('cost_models_wizard.general_info.source_type_label')}
+                  {intl.formatMessage({
+                    id: 'cost_models_wizard.general_info.source_type_label',
+                  })}
                 </Title>
               </SplitItem>
               <SplitItem>{this.props.costModel.source_type}</SplitItem>
@@ -154,22 +159,24 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
   }
 }
 
-export default connect(
-  createMapStateToProps(state => {
-    return {
-      pagination: sourcesSelectors.pagination(state),
-      query: sourcesSelectors.query(state),
-      providers: sourcesSelectors.sources(state),
-      isLoadingSources:
-        sourcesSelectors.status(state) === FetchStatus.inProgress,
-      isUpdateInProgress: costModelsSelectors.updateProcessing(state),
-      updateApiError: costModelsSelectors.updateError(state),
-      fetchingSourcesError: sourcesSelectors.error(state)
-        ? parseApiError(sourcesSelectors.error(state))
-        : '',
-    };
-  }),
-  {
-    fetch: sourcesActions.fetchSources,
-  }
-)(translate()(AddSourceWizardBase));
+export default injectIntl(
+  connect(
+    createMapStateToProps(state => {
+      return {
+        pagination: sourcesSelectors.pagination(state),
+        query: sourcesSelectors.query(state),
+        providers: sourcesSelectors.sources(state),
+        isLoadingSources:
+          sourcesSelectors.status(state) === FetchStatus.inProgress,
+        isUpdateInProgress: costModelsSelectors.updateProcessing(state),
+        updateApiError: costModelsSelectors.updateError(state),
+        fetchingSourcesError: sourcesSelectors.error(state)
+          ? parseApiError(sourcesSelectors.error(state))
+          : '',
+      };
+    }),
+    {
+      fetch: sourcesActions.fetchSources,
+    }
+  )(AddSourceWizardBase)
+);

--- a/src/pages/costModels/costModelsDetails/assignSourcesModalToolbar.tsx
+++ b/src/pages/costModels/costModelsDetails/assignSourcesModalToolbar.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core/dist/esm/experimental';
 import { SearchIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { Omit } from 'react-redux';
 
 interface SearchInputProps {
@@ -52,7 +52,7 @@ const SearchInput: React.SFC<SearchInputProps> = ({
   );
 };
 
-interface AssignSourcesToolbarBaseProps extends InjectedTranslateProps {
+interface AssignSourcesToolbarBaseProps extends WrappedComponentProps {
   paginationProps: PaginationProps;
   searchInputProps: Omit<SearchInputProps, 'placeholder'>;
   filter: {
@@ -63,7 +63,7 @@ interface AssignSourcesToolbarBaseProps extends InjectedTranslateProps {
 }
 
 export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> = ({
-  t,
+  intl,
   searchInputProps,
   paginationProps,
   filter,
@@ -81,9 +81,9 @@ export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> 
             categoryName="name"
           >
             <SearchInput
-              placeholder={t(
-                'cost_models_wizard.source_table.filter_placeholder'
-              )}
+              placeholder={intl.formatMessage({
+                id: 'cost_models_wizard.source_table.filter_placeholder',
+              })}
               {...searchInputProps}
             />
           </DataToolbarFilter>
@@ -96,4 +96,4 @@ export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> 
   );
 };
 
-export const AssignSourcesToolbar = translate()(AssignSourcesToolbarBase);
+export const AssignSourcesToolbar = injectIntl(AssignSourcesToolbarBase);

--- a/src/pages/costModels/costModelsDetails/components/addRateModal.tsx
+++ b/src/pages/costModels/costModelsDetails/components/addRateModal.tsx
@@ -25,14 +25,14 @@ import {
   CurrentStateMachine,
 } from 'pages/costModels/components/addPriceList';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { metricsSelectors } from 'store/metrics';
 import { interpret } from 'xstate';
 import { styles } from './addRateModal.styles';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   current: CostModel;
   isProcessing?: boolean;
   onClose: () => void;
@@ -66,7 +66,7 @@ export class AddRateModelBase extends React.Component<Props, State> {
   }
 
   public renderActionButtons() {
-    const { t, onClose, isProcessing, onProceed } = this.props;
+    const { intl, onClose, isProcessing, onProceed } = this.props;
     const {
       current,
       current: {
@@ -82,7 +82,9 @@ export class AddRateModelBase extends React.Component<Props, State> {
           onClick={onClose}
           isDisabled={isProcessing}
         >
-          {t('cost_models_details.add_rate_modal.cancel')}
+          {intl.formatMessage({
+            id: 'cost_models_details.add_rate_modal.cancel',
+          })}
         </Button>
       );
       const ValidOkButton = (
@@ -92,19 +94,21 @@ export class AddRateModelBase extends React.Component<Props, State> {
           onClick={() => onProceed(metric, measurement, rate, costType)}
           isDisabled={isProcessing}
         >
-          {t('cost_models_details.add_rate')}
+          {intl.formatMessage({ id: 'cost_models_details.add_rate' })}
         </Button>
       );
       return [ValidCancelButton, ValidOkButton];
     }
     const CancelButton = (
       <Button key="cancel" variant={ButtonVariant.secondary} onClick={onClose}>
-        {t('cost_models_details.add_rate_modal.cancel')}
+        {intl.formatMessage({
+          id: 'cost_models_details.add_rate_modal.cancel',
+        })}
       </Button>
     );
     const OkButton = (
       <Button key="proceed" variant={ButtonVariant.primary} isDisabled>
-        {t('cost_models_details.add_rate')}
+        {intl.formatMessage({ id: 'cost_models_details.add_rate' })}
       </Button>
     );
     return [CancelButton, OkButton];
@@ -116,7 +120,7 @@ export class AddRateModelBase extends React.Component<Props, State> {
         context: { metric, measurement, rate, costType },
       },
     } = this.state;
-    const { metricsHash, costTypes, current, t } = this.props;
+    const { metricsHash, costTypes, current, intl } = this.props;
     const { send } = this.service;
     const stateNames = this.state.current.toStrings();
     const mainState = stateNames.length > 1 ? stateNames[1] : stateNames[0];
@@ -133,9 +137,9 @@ export class AddRateModelBase extends React.Component<Props, State> {
       case 'setMetric':
         return (
           <SetMetric
-            t={t}
+            intl={intl}
             options={Object.keys(availableRates).map(r => ({
-              label: t(`cost_models.${r}`),
+              label: intl.formatMessage({ id: `cost_models.${r}` }),
               value: r,
             }))}
             onChange={(value: string) =>
@@ -147,9 +151,9 @@ export class AddRateModelBase extends React.Component<Props, State> {
       case 'setMeasurement':
         return (
           <SetMeasurement
-            t={t}
+            intl={intl}
             metricOptions={Object.keys(availableRates).map(r => ({
-              label: t(`cost_models.${r}`),
+              label: intl.formatMessage({ id: `cost_models.${r}` }),
               value: r,
             }))}
             metricChange={(value: string) =>
@@ -157,9 +161,12 @@ export class AddRateModelBase extends React.Component<Props, State> {
             }
             metric={metric}
             measurementOptions={Object.keys(availableRates[metric]).map(m => ({
-              label: t(`cost_models.${m}`, {
-                units: metricsHash[metric][m].label_measurement_unit,
-              }),
+              label: intl.formatMessage(
+                { id: `cost_models.${m}` },
+                {
+                  units: metricsHash[metric][m].label_measurement_unit,
+                }
+              ),
               value: m,
             }))}
             measurement={measurement}
@@ -179,9 +186,9 @@ export class AddRateModelBase extends React.Component<Props, State> {
         return (
           <>
             <SetRate
-              t={t}
+              intl={intl}
               metricOptions={Object.keys(availableRates).map(r => ({
-                label: t(`cost_models.${r}`),
+                label: intl.formatMessage({ id: `cost_models.${r}` }),
                 value: r,
               }))}
               metricChange={(value: string) =>
@@ -190,9 +197,12 @@ export class AddRateModelBase extends React.Component<Props, State> {
               metric={metric}
               measurementOptions={Object.keys(availableRates[metric] || {}).map(
                 m => ({
-                  label: t(`cost_models.${m}`, {
-                    units: metricsHash[metric][m].label_measurement_unit,
-                  }),
+                  label: intl.formatMessage(
+                    { id: `cost_models.${m}` },
+                    {
+                      units: metricsHash[metric][m].label_measurement_unit,
+                    }
+                  ),
                   value: m,
                 })
               )}
@@ -227,9 +237,9 @@ export class AddRateModelBase extends React.Component<Props, State> {
         return (
           <>
             <SetRate
-              t={t}
+              intl={intl}
               metricOptions={Object.keys(availableRates).map(r => ({
-                label: t(`cost_models.${r}`),
+                label: intl.formatMessage({ id: `cost_models.${r}` }),
                 value: r,
               }))}
               metricChange={(value: string) => {
@@ -239,9 +249,12 @@ export class AddRateModelBase extends React.Component<Props, State> {
               measurement={measurement}
               measurementOptions={Object.keys(availableRates[metric]).map(
                 m => ({
-                  label: t(`cost_models.${m}`, {
-                    units: metricsHash[metric][m].label_measurement_unit,
-                  }),
+                  label: intl.formatMessage(
+                    { id: `cost_models.${m}` },
+                    {
+                      units: metricsHash[metric][m].label_measurement_unit,
+                    }
+                  ),
                   value: m,
                 })
               )}
@@ -277,13 +290,16 @@ export class AddRateModelBase extends React.Component<Props, State> {
   }
 
   public render() {
-    const { updateError, current, onClose, t } = this.props;
+    const { updateError, current, onClose, intl } = this.props;
     return (
       <Modal
         isFooterLeftAligned
-        title={t('cost_models_details.add_rate_modal.title', {
-          name: current.name,
-        })}
+        title={intl.formatMessage(
+          { id: 'cost_models_details.add_rate_modal.title' },
+          {
+            name: current.name,
+          }
+        )}
         isSmall
         isOpen
         onClose={onClose}
@@ -294,7 +310,9 @@ export class AddRateModelBase extends React.Component<Props, State> {
           <Stack gutter="md">
             <StackItem>
               <Title size={TitleSize.lg}>
-                {t('cost_models_details.cost_model.source_type')}
+                {intl.formatMessage({
+                  id: 'cost_models_details.cost_model.source_type',
+                })}
               </Title>
             </StackItem>
             <StackItem>
@@ -317,4 +335,4 @@ export default connect(
     metricsHash: metricsSelectors.metrics(state),
     costTypes: metricsSelectors.costTypes(state),
   }))
-)(translate()(AddRateModelBase));
+)(injectIntl(AddRateModelBase));

--- a/src/pages/costModels/costModelsDetails/components/costModelsDetailsToolbar.tsx
+++ b/src/pages/costModels/costModelsDetails/components/costModelsDetailsToolbar.tsx
@@ -27,7 +27,7 @@ import {
 } from 'pages/costModels/components/filterLogic';
 import { ReadOnlyTooltip } from 'pages/costModels/costModelsDetails/components/readOnlyTooltip';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { Omit } from 'react-redux';
 
 interface SearchInputProps {
@@ -100,12 +100,12 @@ const SingleSelectFilter: React.SFC<SelectFilterProps> = ({
   );
 };
 
-type PrimaryFilterBaseProps = InjectedTranslateProps &
+type PrimaryFilterBaseProps = WrappedComponentProps &
   Omit<SelectFilterProps, 'options'>;
 
-interface CostModelsDetailsToolberBaseProps extends InjectedTranslateProps {
+interface CostModelsDetailsToolberBaseProps extends WrappedComponentProps {
   buttonProps: ButtonProps;
-  primaryProps: Omit<PrimaryFilterBaseProps, 't'>;
+  primaryProps: Omit<PrimaryFilterBaseProps, 'intl'>;
   paginationProps: PaginationProps;
   secondaries: {
     name: string;
@@ -118,7 +118,7 @@ interface CostModelsDetailsToolberBaseProps extends InjectedTranslateProps {
 }
 
 const CostModelsDetailsToolberBase: React.SFC<CostModelsDetailsToolberBaseProps> = ({
-  t,
+  intl,
   chips,
   buttonProps,
   primaryProps,
@@ -143,17 +143,23 @@ const CostModelsDetailsToolberBase: React.SFC<CostModelsDetailsToolberBaseProps>
               options={[
                 {
                   value: 'name',
-                  children: t('toolbar.sources.primary.name'),
+                  children: intl.formatMessage({
+                    id: 'toolbar.sources.primary.name',
+                  }),
                   key: 'name',
                 },
                 {
                   value: 'source_type',
-                  children: t('toolbar.sources.primary.source_type'),
+                  children: intl.formatMessage({
+                    id: 'toolbar.sources.primary.source_type',
+                  }),
                   key: 'source_type',
                 },
                 {
                   value: 'description',
-                  children: t('toolbar.sources.primary.description'),
+                  children: intl.formatMessage({
+                    id: 'toolbar.sources.primary.description',
+                  }),
                   key: 'description',
                 },
               ]}
@@ -165,7 +171,9 @@ const CostModelsDetailsToolberBase: React.SFC<CostModelsDetailsToolberBaseProps>
                 <DataToolbarFilter
                   deleteChip={onRemove}
                   chips={chips[secondary.name]}
-                  categoryName={t(`toolbar.sources.primary.${secondary.name}`)}
+                  categoryName={intl.formatMessage({
+                    id: `toolbar.sources.primary.${secondary.name}`,
+                  })}
                 >
                   {primaryProps.selected === secondary.name &&
                     secondary.render()}
@@ -197,7 +205,7 @@ const CostModelsDetailsToolberBase: React.SFC<CostModelsDetailsToolberBaseProps>
   );
 };
 
-interface CostModelsDetailsToolbarStatefulProps extends InjectedTranslateProps {
+interface CostModelsDetailsToolbarStatefulProps extends WrappedComponentProps {
   paginationProps: PaginationProps;
   buttonProps: ButtonProps;
   onSearch: (searchQuery: { [k: string]: string }) => void;
@@ -226,7 +234,7 @@ class CostModelsDetailsToolbarStateful extends React.Component<
     secondaryValue: '',
   };
   public render() {
-    const { t, paginationProps, buttonProps, onSearch, query } = this.props;
+    const { intl, paginationProps, buttonProps, onSearch, query } = this.props;
     const {
       primaryExpanded,
       primarySelected,
@@ -237,13 +245,22 @@ class CostModelsDetailsToolbarStateful extends React.Component<
       <CostModelsDetailsToolberBase
         onRemove={(category: string, chip: string) => {
           let newQuery;
-          if (category === t('toolbar.sources.primary.name')) {
+          if (
+            category ===
+            intl.formatMessage({ id: 'toolbar.sources.primary.name' })
+          ) {
             newQuery = removeMultiValueQuery(query)('name', chip);
           }
-          if (category === t('toolbar.sources.primary.description')) {
+          if (
+            category ===
+            intl.formatMessage({ id: 'toolbar.sources.primary.description' })
+          ) {
             newQuery = removeMultiValueQuery(query)('description', chip);
           }
-          if (category === t('toolbar.sources.primary.source_type')) {
+          if (
+            category ===
+            intl.formatMessage({ id: 'toolbar.sources.primary.source_type' })
+          ) {
             newQuery = removeSingleValueQuery(query)('source_type', chip);
           }
           return onSearch(newQuery);
@@ -296,9 +313,14 @@ class CostModelsDetailsToolbarStateful extends React.Component<
                       () => onSearch(newQuery)
                     );
                   }}
-                  placeholder={t('toolbar.filterby', {
-                    name: t('toolbar.sources.lower.name'),
-                  })}
+                  placeholder={intl.formatMessage(
+                    { id: 'toolbar.filterby' },
+                    {
+                      name: intl.formatMessage({
+                        id: 'toolbar.sources.lower.name',
+                      }),
+                    }
+                  )}
                 />
               );
             },
@@ -327,9 +349,14 @@ class CostModelsDetailsToolbarStateful extends React.Component<
                       () => onSearch(newQuery)
                     );
                   }}
-                  placeholder={t('toolbar.filterby', {
-                    name: t('toolbar.sources.lower.description'),
-                  })}
+                  placeholder={intl.formatMessage(
+                    { id: 'toolbar.filterby' },
+                    {
+                      name: intl.formatMessage({
+                        id: 'toolbar.sources.lower.description',
+                      }),
+                    }
+                  )}
                 />
               );
             },
@@ -362,24 +389,32 @@ class CostModelsDetailsToolbarStateful extends React.Component<
                   options={[
                     {
                       value: 'none',
-                      children: t('toolbar.sources.secondary.none'),
+                      children: intl.formatMessage({
+                        id: 'toolbar.sources.secondary.none',
+                      }),
                       key: 'none',
                       isPlaceholder: true,
                       isDisabled: true,
                     },
                     {
                       value: 'AWS',
-                      children: t('toolbar.sources.secondary.aws'),
+                      children: intl.formatMessage({
+                        id: 'toolbar.sources.secondary.aws',
+                      }),
                       key: 'aws',
                     },
                     {
                       value: 'OCP',
-                      children: t('toolbar.sources.secondary.ocp'),
+                      children: intl.formatMessage({
+                        id: 'toolbar.sources.secondary.ocp',
+                      }),
                       key: 'ocp',
                     },
                     {
                       value: 'AZURE',
-                      children: t('toolbar.sources.secondary.azure'),
+                      children: intl.formatMessage({
+                        id: 'toolbar.sources.secondary.azure',
+                      }),
                       key: 'azure',
                     },
                   ]}
@@ -388,12 +423,12 @@ class CostModelsDetailsToolbarStateful extends React.Component<
             },
           },
         ]}
-        t={t}
+        intl={intl}
       />
     );
   }
 }
 
-export const CostModelDetailsToolbar = translate()(
+export const CostModelDetailsToolbar = injectIntl(
   CostModelsDetailsToolbarStateful
 );

--- a/src/pages/costModels/costModelsDetails/components/deleteMarkupDialog.tsx
+++ b/src/pages/costModels/costModelsDetails/components/deleteMarkupDialog.tsx
@@ -1,12 +1,12 @@
 import { CostModel } from 'api/costModels';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import Dialog from './dialog';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   isOpen: boolean;
   isLoading: boolean;
   onClose: typeof costModelsActions.setCostModelDialog;
@@ -16,7 +16,7 @@ interface Props extends InjectedTranslateProps {
 }
 
 const DeleteMarkupDialog: React.SFC<Props> = ({
-  t,
+  intl,
   isOpen,
   isLoading,
   onClose,
@@ -28,7 +28,10 @@ const DeleteMarkupDialog: React.SFC<Props> = ({
     <Dialog
       isSmall
       isOpen={isOpen}
-      title={t('dialog.markup.title', { cost_model: current.name })}
+      title={intl.formatMessage(
+        { id: 'dialog.markup.title' },
+        { cost_model: current.name }
+      )}
       onClose={() => onClose({ isOpen: false, name: 'deleteMarkup' })}
       isProcessing={isLoading}
       onProceed={() => {
@@ -43,8 +46,15 @@ const DeleteMarkupDialog: React.SFC<Props> = ({
         };
         updateCostModel(current.uuid, newState, 'deleteMarkup');
       }}
-      body={<>{t('dialog.markup.body', { cost_model: current.name })}</>}
-      actionText={t('dialog.deleteMarkup')}
+      body={
+        <>
+          {intl.formatMessage(
+            { id: 'dialog.markup.body' },
+            { cost_model: current.name }
+          )}
+        </>
+      }
+      actionText={intl.formatMessage({ id: 'dialog.deleteMarkup' })}
       error={error}
     />
   );
@@ -64,4 +74,4 @@ export default connect(
     onClose: costModelsActions.setCostModelDialog,
     updateCostModel: costModelsActions.updateCostModel,
   }
-)(translate()(DeleteMarkupDialog));
+)(injectIntl(DeleteMarkupDialog));

--- a/src/pages/costModels/costModelsDetails/components/dialog.tsx
+++ b/src/pages/costModels/costModelsDetails/components/dialog.tsx
@@ -1,9 +1,9 @@
 import { Alert, Button, Modal, Split, SplitItem } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   isSmall?: boolean;
   onClose: () => void;
   onProceed: () => void;
@@ -16,7 +16,7 @@ interface Props extends InjectedTranslateProps {
 }
 
 const DialogBase: React.SFC<Props> = ({
-  t,
+  intl,
   onClose,
   onProceed,
   title,
@@ -34,7 +34,7 @@ const DialogBase: React.SFC<Props> = ({
       onClick={onClose}
       isDisabled={isProcessing}
     >
-      {t('dialog.cancel')}
+      {intl.formatMessage({ id: 'dialog.cancel' })}
     </Button>
   );
   const ProceedButton = (
@@ -54,7 +54,7 @@ const DialogBase: React.SFC<Props> = ({
       onClick={onClose}
       isDisabled={isProcessing}
     >
-      {t('dialog.close')}
+      {intl.formatMessage({ id: 'dialog.close' })}
     </Button>
   );
   const actions =
@@ -81,4 +81,4 @@ const DialogBase: React.SFC<Props> = ({
   );
 };
 
-export default translate()(DialogBase);
+export default injectIntl(DialogBase);

--- a/src/pages/costModels/costModelsDetails/components/markup.tsx
+++ b/src/pages/costModels/costModelsDetails/components/markup.tsx
@@ -9,7 +9,7 @@ import {
 import { CostModel } from 'api/costModels';
 import { ReadOnlyTooltip } from 'pages/costModels/costModelsDetails/components/readOnlyTooltip';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
@@ -18,7 +18,7 @@ import Dropdown from './dropdown';
 import { styles } from './markup.styles';
 import UpdateMarkupDialog from './updateMarkupDialog';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   isWritePermission: boolean;
   isUpdateDialogOpen: boolean;
   current: CostModel;
@@ -30,7 +30,7 @@ const MarkupCardBase: React.SFC<Props> = ({
   setCostModelDialog,
   current,
   isUpdateDialogOpen,
-  t,
+  intl,
 }) => {
   // Calling current.markup.value is generating an undefined error in prod beta
   const markupValue =
@@ -55,13 +55,19 @@ const MarkupCardBase: React.SFC<Props> = ({
                     }
                     component="button"
                   >
-                    {t('cost_models_details.edit_markup_action')}
+                    {intl.formatMessage({
+                      id: 'cost_models_details.edit_markup_action',
+                    })}
                   </DropdownItem>
                 </ReadOnlyTooltip>,
               ]}
             />
           </CardActions>
-          <CardHeader>{t('cost_models_details.description_markup')}</CardHeader>
+          <CardHeader>
+            {intl.formatMessage({
+              id: 'cost_models_details.description_markup',
+            })}
+          </CardHeader>
         </CardHead>
         <CardBody isFilled />
         <CardBody style={styles.cardBody}>{markupValue}%</CardBody>
@@ -83,4 +89,4 @@ export default connect(
   {
     setCostModelDialog: costModelsActions.setCostModelDialog,
   }
-)(translate()(MarkupCardBase));
+)(injectIntl(MarkupCardBase));

--- a/src/pages/costModels/costModelsDetails/components/priceListTable.tsx
+++ b/src/pages/costModels/costModelsDetails/components/priceListTable.tsx
@@ -24,7 +24,7 @@ import { RateTable } from 'pages/costModels/components/rateTable';
 import { CheckboxSelector } from 'pages/costModels/components/toolbar/checkboxSelector';
 import { PrimarySelector } from 'pages/costModels/components/toolbar/primarySelector';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { FetchStatus } from 'store/common';
 import { createMapStateToProps } from 'store/common';
@@ -44,7 +44,7 @@ interface State {
   };
 }
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   fetchError: AxiosError;
   fetchStatus: FetchStatus;
   current: CostModel;
@@ -72,7 +72,7 @@ class PriceListTable extends React.Component<Props, State> {
   };
   public render() {
     const {
-      t,
+      intl,
       fetchStatus,
       fetchError,
       setDialogOpen,
@@ -83,13 +83,16 @@ class PriceListTable extends React.Component<Props, State> {
       costTypes,
     } = this.props;
     const metricOpts = Object.keys(metricsHash).map(m => ({
-      label: t(`cost_models.${m}`),
+      label: intl.formatMessage({ id: `cost_models.${m}` }),
       value: m,
     }));
     const measurementOpts = metricOpts.reduce((acc, curr) => {
       const measurs = Object.keys(metricsHash[curr.value])
         .filter(m => !acc.map(i => i.value).includes(m))
-        .map(m => ({ label: t(`toolbar.pricelist.options.${m}`), value: m }));
+        .map(m => ({
+          label: intl.formatMessage({ id: `toolbar.pricelist.options.${m}` }),
+          value: m,
+        }));
       return [...acc, ...measurs];
     }, []);
 
@@ -97,7 +100,7 @@ class PriceListTable extends React.Component<Props, State> {
       <>
         {isDialogOpen.updateRate && (
           <UpdateRateModel
-            t={t}
+            intl={intl}
             costTypes={costTypes}
             metricsHash={metricsHash}
             index={this.state.index}
@@ -193,7 +196,10 @@ class PriceListTable extends React.Component<Props, State> {
         <Dialog
           isSmall
           isOpen={isDialogOpen.deleteRate}
-          title={t('dialog.rate.title', { rate: this.state.deleteRate })}
+          title={intl.formatMessage(
+            { id: 'dialog.rate.title' },
+            { rate: this.state.deleteRate }
+          )}
           onClose={() => {
             this.props.setDialogOpen({ name: 'deleteRate', isOpen: false });
             this.setState({ deleteRate: null });
@@ -218,13 +224,16 @@ class PriceListTable extends React.Component<Props, State> {
           }}
           body={
             <>
-              {t('dialog.rate.body', {
-                rate: this.state.deleteRate,
-                cm: this.props.costModel,
-              })}
+              {intl.formatMessage(
+                { id: 'dialog.rate.body' },
+                {
+                  rate: this.state.deleteRate,
+                  cm: this.props.costModel,
+                }
+              )}
               {this.props.assignees && this.props.assignees.length > 0 && (
                 <>
-                  {t('dialog.rate.assigned')}
+                  {intl.formatMessage({ id: 'dialog.rate.assigned' })}
                   <List>
                     {this.props.assignees.map(p => (
                       <ListItem key={p}>{p}</ListItem>
@@ -234,7 +243,7 @@ class PriceListTable extends React.Component<Props, State> {
               )}
             </>
           }
-          actionText={t('dialog.deleteRate')}
+          actionText={intl.formatMessage({ id: 'dialog.deleteRate' })}
         />
         <WithPriceListSearch
           initialFilters={{ primary: 'metrics', metrics: [], measurements: [] }}
@@ -273,11 +282,15 @@ class PriceListTable extends React.Component<Props, State> {
                       setPrimary={(primary: string) => setSearch({ primary })}
                       options={[
                         {
-                          label: t('toolbar.pricelist.metric'),
+                          label: intl.formatMessage({
+                            id: 'toolbar.pricelist.metric',
+                          }),
                           value: 'metrics',
                         },
                         {
-                          label: t('toolbar.pricelist.measurement'),
+                          label: intl.formatMessage({
+                            id: 'toolbar.pricelist.measurement',
+                          }),
                           value: 'measurements',
                         },
                       ]}
@@ -289,9 +302,9 @@ class PriceListTable extends React.Component<Props, State> {
                       component: (
                         <CheckboxSelector
                           isDisabled={this.props.current.rates.length === 0}
-                          placeholderText={t(
-                            'toolbar.pricelist.measurement_placeholder'
-                          )}
+                          placeholderText={intl.formatMessage({
+                            id: 'toolbar.pricelist.measurement_placeholder',
+                          })}
                           selections={search.measurements}
                           setSelections={(selection: string) =>
                             onSelect('measurements', selection)
@@ -307,9 +320,9 @@ class PriceListTable extends React.Component<Props, State> {
                       component: (
                         <CheckboxSelector
                           isDisabled={this.props.current.rates.length === 0}
-                          placeholderText={t(
-                            'toolbar.pricelist.metric_placeholder'
-                          )}
+                          placeholderText={intl.formatMessage({
+                            id: 'toolbar.pricelist.metric_placeholder',
+                          })}
                           selections={search.metrics}
                           setSelections={(selection: string) =>
                             onSelect('metrics', selection)
@@ -336,7 +349,7 @@ class PriceListTable extends React.Component<Props, State> {
                         })
                       }
                     >
-                      {t('toolbar.pricelist.add_rate')}
+                      {intl.formatMessage({ id: 'toolbar.pricelist.add_rate' })}
                     </Button>
                   }
                   onClear={onClearAll}
@@ -370,9 +383,10 @@ class PriceListTable extends React.Component<Props, State> {
                   (search.metrics.length !== 0 ||
                     search.measurements.length !== 0) && (
                     <EmptyFilterState
-                      filter={t(
-                        'cost_models_wizard.price_list.toolbar_top_results_aria_label'
-                      )}
+                      filter={intl.formatMessage({
+                        id:
+                          'cost_models_wizard.price_list.toolbar_top_results_aria_label',
+                      })}
                     />
                   )}
                 {fetchStatus === FetchStatus.complete &&
@@ -383,30 +397,39 @@ class PriceListTable extends React.Component<Props, State> {
                       <EmptyState>
                         <EmptyStateIcon icon={FileInvoiceDollarIcon} />
                         <Title size={TitleSize.lg}>
-                          {t('cost_models_details.empty_state_rate.title')}
+                          {intl.formatMessage({
+                            id: 'cost_models_details.empty_state_rate.title',
+                          })}
                         </Title>
                         <EmptyStateBody>
-                          {t(
-                            'cost_models_details.empty_state_rate.description'
-                          )}
+                          {intl.formatMessage({
+                            id:
+                              'cost_models_details.empty_state_rate.description',
+                          })}
                         </EmptyStateBody>
                       </EmptyState>
                     </Bullseye>
                   )}
                 {fetchStatus === FetchStatus.complete && filtered.length > 0 && (
                   <RateTable
-                    t={t}
+                    intl={intl}
                     tiers={filtered}
                     actions={[
                       {
-                        title: t('cost_models_wizard.price_list.update_button'),
+                        title: intl.formatMessage({
+                          id: 'cost_models_wizard.price_list.update_button',
+                        }),
                         isDisabled: !isWritePermission,
                         // HACK: to display tooltip on disable
                         style: !isWritePermission
                           ? { pointerEvents: 'auto' }
                           : undefined,
                         tooltip: !isWritePermission ? (
-                          <div>{t('cost_models.read_only_tooltip')}</div>
+                          <div>
+                            {intl.formatMessage({
+                              id: 'cost_models.read_only_tooltip',
+                            })}
+                          </div>
                         ) : (
                           undefined
                         ),
@@ -422,14 +445,20 @@ class PriceListTable extends React.Component<Props, State> {
                         },
                       },
                       {
-                        title: t('cost_models_wizard.price_list.delete_button'),
+                        title: intl.formatMessage({
+                          id: 'cost_models_wizard.price_list.delete_button',
+                        }),
                         isDisabled: !isWritePermission,
                         // HACK: to display tooltip on disable
                         style: !isWritePermission
                           ? { pointerEvents: 'auto' }
                           : { color: 'red' },
                         tooltip: !isWritePermission ? (
-                          <div>{t('cost_models.read_only_tooltip')}</div>
+                          <div>
+                            {intl.formatMessage({
+                              id: 'cost_models.read_only_tooltip',
+                            })}
+                          </div>
                         ) : (
                           undefined
                         ),
@@ -456,20 +485,22 @@ class PriceListTable extends React.Component<Props, State> {
   }
 }
 
-export default connect(
-  createMapStateToProps(state => ({
-    isLoading: costModelsSelectors.updateProcessing(state),
-    error: costModelsSelectors.updateError(state),
-    isDialogOpen: costModelsSelectors.isDialogOpen(state)('rate'),
-    fetchError: costModelsSelectors.error(state),
-    fetchStatus: costModelsSelectors.status(state),
-    metricsHash: metricsSelectors.metrics(state),
-    maxRate: metricsSelectors.maxRate(state),
-    costTypes: metricsSelectors.costTypes(state),
-    isWritePermission: rbacSelectors.isCostModelWritePermission(state),
-  })),
-  {
-    updateCostModel: costModelsActions.updateCostModel,
-    setDialogOpen: costModelsActions.setCostModelDialog,
-  }
-)(translate()(PriceListTable));
+export default injectIntl(
+  connect(
+    createMapStateToProps(state => ({
+      isLoading: costModelsSelectors.updateProcessing(state),
+      error: costModelsSelectors.updateError(state),
+      isDialogOpen: costModelsSelectors.isDialogOpen(state)('rate'),
+      fetchError: costModelsSelectors.error(state),
+      fetchStatus: costModelsSelectors.status(state),
+      metricsHash: metricsSelectors.metrics(state),
+      maxRate: metricsSelectors.maxRate(state),
+      costTypes: metricsSelectors.costTypes(state),
+      isWritePermission: rbacSelectors.isCostModelWritePermission(state),
+    })),
+    {
+      updateCostModel: costModelsActions.updateCostModel,
+      setDialogOpen: costModelsActions.setCostModelDialog,
+    }
+  )(PriceListTable)
+);

--- a/src/pages/costModels/costModelsDetails/components/readOnlyTooltip.tsx
+++ b/src/pages/costModels/costModelsDetails/components/readOnlyTooltip.tsx
@@ -1,21 +1,23 @@
 import { Tooltip } from '@patternfly/react-core';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 
-interface ReadOnlyTooltipBase extends InjectedTranslateProps {
+interface ReadOnlyTooltipBase extends WrappedComponentProps {
   children: JSX.Element;
   isDisabled: boolean;
 }
 
 export const ReadOnlyTooltipBase: React.SFC<ReadOnlyTooltipBase> = ({
   children,
-  t,
+  intl,
   isDisabled,
 }) => {
   return isDisabled ? (
     <Tooltip
       isContentLeftAligned
-      content={<div>{t('cost_models.read_only_tooltip')}</div>}
+      content={
+        <div>{intl.formatMessage({ id: 'cost_models.read_only_tooltip' })}</div>
+      }
     >
       <div data-testid="read-only-tooltip">{children}</div>
     </Tooltip>
@@ -24,4 +26,4 @@ export const ReadOnlyTooltipBase: React.SFC<ReadOnlyTooltipBase> = ({
   );
 };
 
-export const ReadOnlyTooltip = translate()(ReadOnlyTooltipBase);
+export const ReadOnlyTooltip = injectIntl(ReadOnlyTooltipBase);

--- a/src/pages/costModels/costModelsDetails/components/table.tsx
+++ b/src/pages/costModels/costModelsDetails/components/table.tsx
@@ -17,14 +17,14 @@ import {
   removeMultiValueQuery,
 } from 'pages/costModels/components/filterLogic';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { rbacSelectors } from 'store/rbac';
 import { SourcesToolbar } from './sourcesToolbar';
 import { styles } from './table.styles';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   isWritePermission: boolean;
   rows: string[];
   cells: string[];
@@ -54,7 +54,7 @@ class TableBase extends React.Component<Props, State> {
     const {
       pagination: { page, perPage },
     } = this.state;
-    const { onAdd, t, rows, cells, isWritePermission } = this.props;
+    const { onAdd, intl, rows, cells, isWritePermission } = this.props;
     const filteredRows = rows
       .filter(uuid => {
         if (!Boolean(this.state.query.name)) {
@@ -70,7 +70,9 @@ class TableBase extends React.Component<Props, State> {
           actionButtonProps={{
             isDisabled: !isWritePermission,
             onClick: onAdd,
-            children: t('toolbar.sources.assign_sources'),
+            children: intl.formatMessage({
+              id: 'toolbar.sources.assign_sources',
+            }),
           }}
           filter={{
             onClearAll: () =>
@@ -85,7 +87,9 @@ class TableBase extends React.Component<Props, State> {
               });
             },
             query: this.state.query,
-            categoryNames: { name: t('toolbar.sources.category.name') },
+            categoryNames: {
+              name: intl.formatMessage({ id: 'toolbar.sources.category.name' }),
+            },
           }}
           paginationProps={{
             itemCount: filteredRows.length,
@@ -120,7 +124,9 @@ class TableBase extends React.Component<Props, State> {
               });
             },
             value: this.state.currentFilter,
-            placeholder: t('toolbar.sources.filter_placeholder'),
+            placeholder: intl.formatMessage({
+              id: 'toolbar.sources.filter_placeholder',
+            }),
           }}
         />
         {res.length > 0 && (
@@ -132,14 +138,20 @@ class TableBase extends React.Component<Props, State> {
               this.props.onDelete && {
                 title:
                   this.props.onDeleteText ||
-                  t('cost_models_details.action_delete'),
+                  intl.formatMessage({
+                    id: 'cost_models_details.action_delete',
+                  }),
                 isDisabled: !isWritePermission,
                 // HACK: to display tooltip on disable
                 style: !isWritePermission
                   ? { pointerEvents: 'auto' }
                   : undefined,
                 tooltip: !isWritePermission ? (
-                  <div>{t('cost_models.read_only_tooltip')}</div>
+                  <div>
+                    {intl.formatMessage({
+                      id: 'cost_models.read_only_tooltip',
+                    })}
+                  </div>
                 ) : (
                   undefined
                 ),
@@ -158,10 +170,14 @@ class TableBase extends React.Component<Props, State> {
             <EmptyState>
               <EmptyStateIcon icon={DollarSignIcon} />
               <Title size="lg">
-                {t('cost_models_details.empty_state_source.title')}
+                {intl.formatMessage({
+                  id: 'cost_models_details.empty_state_source.title',
+                })}
               </Title>
               <EmptyStateBody>
-                {t('cost_models_details.empty_state_source.description')}
+                {intl.formatMessage({
+                  id: 'cost_models_details.empty_state_source.description',
+                })}
               </EmptyStateBody>
             </EmptyState>
           </div>
@@ -169,12 +185,14 @@ class TableBase extends React.Component<Props, State> {
         {filteredRows.length === 0 && rows.length > 0 && (
           <EmptyFilterState
             filter={this.state.currentFilter}
-            subTitle={t('no_match_found_state.desc')}
+            subTitle={intl.formatMessage({ id: 'no_match_found_state.desc' })}
           />
         )}
         <DataToolbar id="costmodels_details_filter_datatoolbar">
           <DataToolbarContent
-            aria-label={t('cost_models_details.sources_filter_controller')}
+            aria-label={intl.formatMessage({
+              id: 'cost_models_details.sources_filter_controller',
+            })}
             style={{ flexDirection: 'row-reverse' }}
           >
             <DataToolbarGroup>
@@ -210,4 +228,4 @@ export default connect(
   createMapStateToProps(state => ({
     isWritePermission: rbacSelectors.isCostModelWritePermission(state),
   }))
-)(translate()(TableBase));
+)(injectIntl(TableBase));

--- a/src/pages/costModels/costModelsDetails/components/updateCostModel.tsx
+++ b/src/pages/costModels/costModelsDetails/components/updateCostModel.tsx
@@ -9,12 +9,12 @@ import {
 } from '@patternfly/react-core';
 import { CostModel } from 'api/costModels';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   current: CostModel;
   isProcessing: boolean;
   onProceed?: () => void;
@@ -43,14 +43,17 @@ class UpdateCostModelBase extends React.Component<Props, State> {
       current,
       isProcessing,
       setDialogOpen,
-      t,
+      intl,
     } = this.props;
     return (
       <Modal
         isFooterLeftAligned
-        title={t('cost_models_details.edit_cost_model', {
-          cost_model: current.name,
-        })}
+        title={intl.formatMessage(
+          { id: 'cost_models_details.edit_cost_model' },
+          {
+            cost_model: current.name,
+          }
+        )}
         isOpen
         isSmall
         onClose={() =>
@@ -65,7 +68,7 @@ class UpdateCostModelBase extends React.Component<Props, State> {
             }
             isDisabled={isProcessing}
           >
-            {t('dialog.cancel')}
+            {intl.formatMessage({ id: 'dialog.cancel' })}
           </Button>,
           <Button
             key="proceed"
@@ -99,7 +102,7 @@ class UpdateCostModelBase extends React.Component<Props, State> {
                 this.state.description === this.props.current.description)
             }
           >
-            {t('cost_models_details.save_button')}
+            {intl.formatMessage({ id: 'cost_models_details.save_button' })}
           </Button>,
         ]}
       >
@@ -107,7 +110,9 @@ class UpdateCostModelBase extends React.Component<Props, State> {
           {updateError && <Alert variant="danger" title={`${updateError}`} />}
           <Form>
             <FormGroup
-              label={t('cost_models_wizard.general_info.name_label')}
+              label={intl.formatMessage({
+                id: 'cost_models_wizard.general_info.name_label',
+              })}
               isRequired
               fieldId="name"
             >
@@ -121,7 +126,9 @@ class UpdateCostModelBase extends React.Component<Props, State> {
               />
             </FormGroup>
             <FormGroup
-              label={t('cost_models_wizard.general_info.description_label')}
+              label={intl.formatMessage({
+                id: 'cost_models_wizard.general_info.description_label',
+              })}
               fieldId="description"
             >
               <TextArea
@@ -139,14 +146,16 @@ class UpdateCostModelBase extends React.Component<Props, State> {
   }
 }
 
-export default connect(
-  createMapStateToProps(state => ({
-    isProcessing: costModelsSelectors.updateProcessing(state),
-    updateError: costModelsSelectors.updateError(state),
-    current: costModelsSelectors.selected(state),
-  })),
-  {
-    setDialogOpen: costModelsActions.setCostModelDialog,
-    updateCostModel: costModelsActions.updateCostModel,
-  }
-)(translate()(UpdateCostModelBase));
+export default injectIntl(
+  connect(
+    createMapStateToProps(state => ({
+      isProcessing: costModelsSelectors.updateProcessing(state),
+      updateError: costModelsSelectors.updateError(state),
+      current: costModelsSelectors.selected(state),
+    })),
+    {
+      setDialogOpen: costModelsActions.setCostModelDialog,
+      updateCostModel: costModelsActions.updateCostModel,
+    }
+  )(UpdateCostModelBase)
+);

--- a/src/pages/costModels/costModelsDetails/components/updateMarkupDialog.tsx
+++ b/src/pages/costModels/costModelsDetails/components/updateMarkupDialog.tsx
@@ -10,12 +10,12 @@ import {
 } from '@patternfly/react-core';
 import { CostModel } from 'api/costModels';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   isLoading: boolean;
   onClose: typeof costModelsActions.setCostModelDialog;
   updateCostModel: typeof costModelsActions.updateCostModel;
@@ -41,14 +41,17 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
       onClose,
       updateCostModel,
       isLoading,
-      t,
+      intl,
     } = this.props;
     return (
       <Modal
         isFooterLeftAligned
-        title={t('cost_models_details.edit_markup', {
-          cost_model: current.name,
-        })}
+        title={intl.formatMessage(
+          { id: 'cost_models_details.edit_markup' },
+          {
+            cost_model: current.name,
+          }
+        )}
         isOpen
         isSmall
         onClose={() => onClose({ name: 'updateMarkup', isOpen: false })}
@@ -59,7 +62,9 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
             onClick={() => onClose({ name: 'updateMarkup', isOpen: false })}
             isDisabled={isLoading}
           >
-            {t('cost_models_details.add_rate_modal.cancel')}
+            {intl.formatMessage({
+              id: 'cost_models_details.add_rate_modal.cancel',
+            })}
           </Button>,
           <Button
             key="proceed"
@@ -85,7 +90,9 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
               isLoading
             }
           >
-            {t('cost_models_details.add_rate_modal.save')}
+            {intl.formatMessage({
+              id: 'cost_models_details.add_rate_modal.save',
+            })}
           </Button>,
         ]}
       >
@@ -93,17 +100,21 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
           {error && <Alert variant="danger" title={`${error}`} />}
           <Form>
             <FormGroup
-              label={t('cost_models_wizard.markup.markup_label')}
+              label={intl.formatMessage({
+                id: 'cost_models_wizard.markup.markup_label',
+              })}
               fieldId="markup-input-box"
-              helperTextInvalid={t(
-                'cost_models_wizard.markup.invalid_markup_text'
-              )}
+              helperTextInvalid={intl.formatMessage({
+                id: 'cost_models_wizard.markup.invalid_markup_text',
+              })}
               isValid={!isNaN(Number(this.state.markup))}
             >
               <InputGroup style={{ width: '150px' }}>
                 <TextInput
                   type="text"
-                  aria-label={t('cost_models_wizard.markup.markup_label')}
+                  aria-label={intl.formatMessage({
+                    id: 'cost_models_wizard.markup.markup_label',
+                  })}
                   id="markup-input-box"
                   value={this.state.markup}
                   onChange={(markup: string) => this.setState({ markup })}
@@ -119,16 +130,18 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
   }
 }
 
-export default connect(
-  createMapStateToProps(state => {
-    return {
-      isLoading: costModelsSelectors.updateProcessing(state),
-      error: costModelsSelectors.updateError(state),
-      current: costModelsSelectors.selected(state),
-    };
-  }),
-  {
-    onClose: costModelsActions.setCostModelDialog,
-    updateCostModel: costModelsActions.updateCostModel,
-  }
-)(translate()(UpdateMarkupModelBase));
+export default injectIntl(
+  connect(
+    createMapStateToProps(state => {
+      return {
+        isLoading: costModelsSelectors.updateProcessing(state),
+        error: costModelsSelectors.updateError(state),
+        current: costModelsSelectors.selected(state),
+      };
+    }),
+    {
+      onClose: costModelsActions.setCostModelDialog,
+      updateCostModel: costModelsActions.updateCostModel,
+    }
+  )(UpdateMarkupModelBase)
+);

--- a/src/pages/costModels/costModelsDetails/components/updateRateModel.tsx
+++ b/src/pages/costModels/costModelsDetails/components/updateRateModel.tsx
@@ -24,9 +24,9 @@ import {
   isRateValid,
 } from 'pages/costModels/components/addCostModelRateForm';
 import React from 'react';
-import { InjectedTranslateProps } from 'react-i18next';
+import { WrappedComponentProps } from 'react-intl';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   index: number;
   current: CostModel;
   isProcessing: boolean;
@@ -64,7 +64,7 @@ class UpdateRateModelBase extends React.Component<Props, State> {
       onClose,
       onProceed,
       isProcessing,
-      t,
+      intl,
       index,
       metricsHash,
       costTypes,
@@ -79,7 +79,7 @@ class UpdateRateModelBase extends React.Component<Props, State> {
     return (
       <Modal
         isFooterLeftAligned
-        title={t('cost_models_details.edit_rate')}
+        title={intl.formatMessage({ id: 'cost_models_details.edit_rate' })}
         isOpen
         isSmall
         onClose={onClose}
@@ -90,7 +90,9 @@ class UpdateRateModelBase extends React.Component<Props, State> {
             onClick={onClose}
             isDisabled={isProcessing}
           >
-            {t('cost_models_details.add_rate_modal.cancel')}
+            {intl.formatMessage({
+              id: 'cost_models_details.add_rate_modal.cancel',
+            })}
           </Button>,
           <Button
             key="proceed"
@@ -110,7 +112,9 @@ class UpdateRateModelBase extends React.Component<Props, State> {
                 this.state.rate === originalRate)
             }
           >
-            {t('cost_models_details.add_rate_modal.save')}
+            {intl.formatMessage({
+              id: 'cost_models_details.add_rate_modal.save',
+            })}
           </Button>,
         ]}
       >
@@ -119,7 +123,9 @@ class UpdateRateModelBase extends React.Component<Props, State> {
           <Stack gutter="md">
             <StackItem>
               <Title size={TitleSize.lg}>
-                {t('cost_models_details.cost_model.source_type')}
+                {intl.formatMessage({
+                  id: 'cost_models_details.cost_model.source_type',
+                })}
               </Title>
             </StackItem>
             <StackItem>
@@ -130,41 +136,50 @@ class UpdateRateModelBase extends React.Component<Props, State> {
 
             <StackItem>
               <Title size={TitleSize.lg}>
-                {t('cost_models.add_rate_form.metric_select')}
+                {intl.formatMessage({
+                  id: 'cost_models.add_rate_form.metric_select',
+                })}
               </Title>
             </StackItem>
             <StackItem>
               <TextContent>
                 <Text component={TextVariants.h6}>
-                  {t(`cost_models.${metric}`)}
+                  {intl.formatMessage({ id: `cost_models.${metric}` })}
                 </Text>
               </TextContent>
             </StackItem>
 
             <StackItem>
               <Title size={TitleSize.lg}>
-                {t('cost_models.add_rate_form.measurement_select')}
+                {intl.formatMessage({
+                  id: 'cost_models.add_rate_form.measurement_select',
+                })}
               </Title>
             </StackItem>
             <StackItem>
               <TextContent>
                 <Text component={TextVariants.h6}>
-                  {t(`cost_models.${measurement}`, {
-                    units: t(
-                      `cost_models.${metricsHash[metric][measurement].label_measurement_unit}`
-                    ),
-                  })}
+                  {intl.formatMessage(
+                    { id: `cost_models.${measurement}` },
+                    {
+                      units: intl.formatMessage({
+                        id: `cost_models.${metricsHash[metric][measurement].label_measurement_unit}`,
+                      }),
+                    }
+                  )}
                 </Text>
               </TextContent>
             </StackItem>
             <StackItem>
               <Form>
                 <FormGroup
-                  label={t('cost_models.add_rate_form.rate_input')}
+                  label={intl.formatMessage({
+                    id: 'cost_models.add_rate_form.rate_input',
+                  })}
                   fieldId="rate-input-box"
-                  helperTextInvalid={t(
-                    'cost_models.add_rate_form.error_message'
-                  )}
+                  helperTextInvalid={intl.formatMessage({
+                    id: 'cost_models.add_rate_form.error_message',
+                  })}
                   isValid={isRateValid(this.state.rate)}
                 >
                   <InputGroup style={{ width: '350px' }}>
@@ -174,9 +189,9 @@ class UpdateRateModelBase extends React.Component<Props, State> {
                     <TextInput
                       style={{ borderLeft: '0' }}
                       type="text"
-                      aria-label={t(
-                        'cost_models_wizard.price_list.rate_aria_label'
-                      )}
+                      aria-label={intl.formatMessage({
+                        id: 'cost_models_wizard.price_list.rate_aria_label',
+                      })}
                       id="rate-input-box"
                       value={this.state.rate}
                       onChange={(rate: string) => this.setState({ rate })}
@@ -186,7 +201,7 @@ class UpdateRateModelBase extends React.Component<Props, State> {
                 </FormGroup>
                 <div style={{ width: '350px' }}>
                   <CostTypeSelectorBase
-                    t={t}
+                    intl={intl}
                     costTypes={costTypes}
                     value={this.state.costType}
                     onChange={value => this.setState({ costType: value })}

--- a/src/pages/costModels/costModelsDetails/costModelInfo/header.tsx
+++ b/src/pages/costModels/costModelsDetails/costModelInfo/header.tsx
@@ -18,13 +18,13 @@ import { ReadOnlyTooltip } from 'pages/costModels/costModelsDetails/components/r
 import UpdateCostModelDialog from 'pages/costModels/costModelsDetails/components/updateCostModel';
 import { styles } from 'pages/costModels/costModelsDetails/costModelsDetails.styles';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { rbacSelectors } from 'store/rbac';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   goBack: () => void;
   tabRefs: any[];
   tabIndex: number;
@@ -45,7 +45,7 @@ class Header extends React.Component<Props> {
   }
   public render() {
     const {
-      t,
+      intl,
       tabRefs,
       tabIndex,
       onSelectTab,
@@ -64,9 +64,12 @@ class Header extends React.Component<Props> {
         <Dialog
           isSmall
           isOpen={isDialogOpen.deleteCostModel}
-          title={t('dialog.delete_cost_model_title', {
-            cost_model: current.name,
-          })}
+          title={intl.formatMessage(
+            { id: 'dialog.delete_cost_model_title' },
+            {
+              cost_model: current.name,
+            }
+          )}
           onClose={() =>
             setDialogOpen({ name: 'deleteCostModel', isOpen: false })
           }
@@ -78,17 +81,25 @@ class Header extends React.Component<Props> {
           body={
             <>
               {current.sources.length === 0 &&
-                t('dialog.delete_cost_model_body_green', {
-                  cost_model: current.name,
-                })}
+                intl.formatMessage(
+                  { id: 'dialog.delete_cost_model_body_green' },
+                  {
+                    cost_model: current.name,
+                  }
+                )}
               {current.sources.length > 0 && (
                 <>
-                  {t('dialog.delete_cost_model_body_red', {
-                    cost_model: current.name,
+                  {intl.formatMessage(
+                    { id: 'dialog.delete_cost_model_body_red' },
+                    {
+                      cost_model: current.name,
+                    }
+                  )}
+                  <br />
+                  <br />
+                  {intl.formatMessage({
+                    id: 'dialog.delete_cost_model_body_red_costmodel_delete',
                   })}
-                  <br />
-                  <br />
-                  {t('dialog.delete_cost_model_body_red_costmodel_delete')}
                   <br />
                   <List>
                     {current.sources.map(provider => (
@@ -102,7 +113,9 @@ class Header extends React.Component<Props> {
             </>
           }
           actionText={
-            current.sources.length === 0 ? t('dialog.deleteCostModel') : ''
+            current.sources.length === 0
+              ? intl.formatMessage({ id: 'dialog.deleteCostModel' })
+              : ''
           }
         />
         <header ref={this.cmpRef} style={styles.headerCostModel}>
@@ -113,7 +126,9 @@ class Header extends React.Component<Props> {
                 onClick={goBack}
                 variant="link"
               >
-                {t('cost_models_details.cost_model.cost_models')}
+                {intl.formatMessage({
+                  id: 'cost_models_details.cost_model.cost_models',
+                })}
               </Button>
             </BreadcrumbItem>
             <BreadcrumbItem isActive>{current.name}</BreadcrumbItem>
@@ -132,8 +147,10 @@ class Header extends React.Component<Props> {
                 </>
               )}
               <Title style={styles.title} size="md">
-                {t('cost_models_details.cost_model.source_type')}:{' '}
-                {current.source_type}
+                {intl.formatMessage({
+                  id: 'cost_models_details.cost_model.source_type',
+                })}
+                : }{current.source_type}
               </Title>
               {current.source_type === 'OpenShift Container Platform' ? (
                 <Tabs
@@ -194,7 +211,9 @@ class Header extends React.Component<Props> {
                         })
                       }
                     >
-                      {t('cost_models_details.action_edit')}
+                      {intl.formatMessage({
+                        id: 'cost_models_details.action_edit',
+                      })}
                     </DropdownItem>
                   </ReadOnlyTooltip>,
                   <ReadOnlyTooltip key="delete" isDisabled={!isWritePermission}>
@@ -208,7 +227,9 @@ class Header extends React.Component<Props> {
                       }
                       style={isWritePermission ? { color: 'red' } : undefined}
                     >
-                      {t('cost_models_details.action_delete')}
+                      {intl.formatMessage({
+                        id: 'cost_models_details.action_delete',
+                      })}
                     </DropdownItem>
                   </ReadOnlyTooltip>,
                 ]}
@@ -221,16 +242,18 @@ class Header extends React.Component<Props> {
   }
 }
 
-export default connect(
-  createMapStateToProps(state => ({
-    isDialogOpen: costModelsSelectors.isDialogOpen(state)('costmodel'),
-    isDeleteProcessing: costModelsSelectors.deleteProcessing(state),
-    deleteError: costModelsSelectors.deleteError(state),
-    current: costModelsSelectors.selected(state),
-    isWritePermission: rbacSelectors.isCostModelWritePermission(state),
-  })),
-  {
-    setDialogOpen: costModelsActions.setCostModelDialog,
-    deleteCostModel: costModelsActions.deleteCostModel,
-  }
-)(translate()(Header));
+export default injectIntl(
+  connect(
+    createMapStateToProps(state => ({
+      isDialogOpen: costModelsSelectors.isDialogOpen(state)('costmodel'),
+      isDeleteProcessing: costModelsSelectors.deleteProcessing(state),
+      deleteError: costModelsSelectors.deleteError(state),
+      current: costModelsSelectors.selected(state),
+      isWritePermission: rbacSelectors.isCostModelWritePermission(state),
+    })),
+    {
+      setDialogOpen: costModelsActions.setCostModelDialog,
+      deleteCostModel: costModelsActions.deleteCostModel,
+    }
+  )(Header)
+);

--- a/src/pages/costModels/costModelsDetails/costModelsDetails.tsx
+++ b/src/pages/costModels/costModelsDetails/costModelsDetails.tsx
@@ -5,11 +5,11 @@ import { ErrorState } from 'components/state/errorState/errorState';
 import { LoadingState } from 'components/state/loadingState/loadingState';
 import { CostModelWizard } from 'pages/costModels/createCostModelWizard';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FetchStatus } from 'store/common';
 import { costModelsActions } from 'store/costModels';
 import { metricsActions } from 'store/metrics';
 import { rbacActions } from 'store/rbac';
+import { intl } from '../../../components/i18nProvider';
 import { CostModelDetailsToolbar } from './components/costModelsDetailsToolbar';
 import CostModelInformation from './costModelInfo';
 import { styles } from './costModelsDetails.styles';
@@ -18,7 +18,7 @@ import CostModelsTable from './costModelsTable';
 import EmptyState from './emptyState';
 import Header from './header';
 
-interface Props extends InjectedTranslateProps {
+interface Props {
   costModels: CostModel[];
   error: AxiosError;
   status: FetchStatus;
@@ -145,15 +145,18 @@ class CostModelsDetails extends React.Component<Props, State> {
       pagination,
       status,
       error,
-      t,
       query,
     } = this.props;
     const columns = [
-      t('cost_models_details.table.columns.name'),
-      t('cost_models_details.table.columns.desc'),
-      t('cost_models_details.table.columns.source_type'),
-      t('cost_models_details.table.columns.sources'),
-      t('cost_models_details.table.columns.last_modified'),
+      intl.formatMessage({ id: 'cost_models_details.table.columns.name' }),
+      intl.formatMessage({ id: 'cost_models_details.table.columns.desc' }),
+      intl.formatMessage({
+        id: 'cost_models_details.table.columns.source_type',
+      }),
+      intl.formatMessage({ id: 'cost_models_details.table.columns.sources' }),
+      intl.formatMessage({
+        id: 'cost_models_details.table.columns.last_modified',
+      }),
       '',
     ];
     const filterValue = Object.keys(query)
@@ -168,7 +171,7 @@ class CostModelsDetails extends React.Component<Props, State> {
           openWizard={() => this.setState({ isWizardOpen: true })}
         />
         <div style={styles.sourceSettings}>
-          <Header t={t} />
+          <Header intl={intl} />
           <div style={styles.content}>
             {status !== FetchStatus.none &&
               error === null &&
@@ -178,7 +181,9 @@ class CostModelsDetails extends React.Component<Props, State> {
                     buttonProps={{
                       isDisabled: !isWritePermission,
                       onClick: () => this.setState({ isWizardOpen: true }),
-                      children: t('cost_models_details.filter.create_button'),
+                      children: intl.formatMessage({
+                        id: 'cost_models_details.filter.create_button',
+                      }),
                     }}
                     query={Object.keys(query).reduce((acc, cur) => {
                       if (
@@ -261,7 +266,9 @@ class CostModelsDetails extends React.Component<Props, State> {
               costModels.length === 0 && (
                 <EmptyFilterState
                   filter={this.props.query.name}
-                  subTitle={t('no_match_found_state.desc')}
+                  subTitle={intl.formatMessage({
+                    id: 'no_match_found_state.desc',
+                  })}
                 />
               )}
           </div>
@@ -278,4 +285,4 @@ class CostModelsDetails extends React.Component<Props, State> {
   }
 }
 
-export default translate()(CostModelsDetails);
+export default CostModelsDetails;

--- a/src/pages/costModels/costModelsDetails/costModelsTable.tsx
+++ b/src/pages/costModels/costModelsDetails/costModelsTable.tsx
@@ -10,7 +10,7 @@ import {
 import { CostModel } from 'api/costModels';
 import { relativeTime } from 'human-date';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
@@ -18,7 +18,7 @@ import Dialog from './components/dialog';
 import { styles } from './costModelsDetails.styles';
 import { costModelsTableMap, getSortByData, reverseMap } from './sort';
 
-interface TableProps extends InjectedTranslateProps {
+interface TableProps extends WrappedComponentProps {
   isWritePermissions: boolean;
   columns: string[];
   rows: CostModel[];
@@ -49,7 +49,7 @@ class CostModelsTable extends React.Component<TableProps, TableState> {
       setDialogOpen,
       columns,
       rows,
-      t,
+      intl,
       setUuid,
       onOrdering,
       sortBy,
@@ -78,7 +78,10 @@ class CostModelsTable extends React.Component<TableProps, TableState> {
         <Dialog
           isSmall
           isOpen={isDialogOpen.deleteCostModel}
-          title={t('dialog.delete_cost_model_title', { cost_model: cm.name })}
+          title={intl.formatMessage(
+            { id: 'dialog.delete_cost_model_title' },
+            { cost_model: cm.name }
+          )}
           onClose={() =>
             setDialogOpen({ name: 'deleteCostModel', isOpen: false })
           }
@@ -90,17 +93,25 @@ class CostModelsTable extends React.Component<TableProps, TableState> {
           body={
             <>
               {cm.sources.length === 0 &&
-                t('dialog.delete_cost_model_body_green', {
-                  cost_model: cm.name,
-                })}
+                intl.formatMessage(
+                  { id: 'dialog.delete_cost_model_body_green' },
+                  {
+                    cost_model: cm.name,
+                  }
+                )}
               {cm.sources.length > 0 && (
                 <>
-                  {t('dialog.delete_cost_model_body_red', {
-                    cost_model: cm.name,
+                  {intl.formatMessage(
+                    { id: 'dialog.delete_cost_model_body_red' },
+                    {
+                      cost_model: cm.name,
+                    }
+                  )}
+                  <br />
+                  <br />
+                  {intl.formatMessage({
+                    id: 'dialog.delete_cost_model_body_red_costmodel_delete',
                   })}
-                  <br />
-                  <br />
-                  {t('dialog.delete_cost_model_body_red_costmodel_delete')}
                   <br />
                   <List>
                     {cm.sources.map(provider => (
@@ -115,7 +126,7 @@ class CostModelsTable extends React.Component<TableProps, TableState> {
           }
           actionText={
             rows[this.state.rowId].sources.length === 0
-              ? t('dialog.deleteCostModel')
+              ? intl.formatMessage({ id: 'dialog.deleteCostModel' })
               : ''
           }
         />
@@ -150,9 +161,15 @@ class CostModelsTable extends React.Component<TableProps, TableState> {
             cells={columns.map(cell => {
               if (
                 [
-                  t('cost_models_details.table.columns.name'),
-                  t('cost_models_details.table.columns.source_type'),
-                  t('cost_models_details.table.columns.last_modified'),
+                  intl.formatMessage({
+                    id: 'cost_models_details.table.columns.name',
+                  }),
+                  intl.formatMessage({
+                    id: 'cost_models_details.table.columns.source_type',
+                  }),
+                  intl.formatMessage({
+                    id: 'cost_models_details.table.columns.last_modified',
+                  }),
                 ].includes(cell)
               ) {
                 return {
@@ -165,7 +182,9 @@ class CostModelsTable extends React.Component<TableProps, TableState> {
             rows={linkedRows}
             actions={[
               {
-                title: t('cost_models_details.action_view'),
+                title: intl.formatMessage({
+                  id: 'cost_models_details.action_view',
+                }),
                 onClick: (_evt, rowId) => {
                   setUuid(rows[rowId].uuid);
                 },
@@ -176,17 +195,25 @@ class CostModelsTable extends React.Component<TableProps, TableState> {
                   ? { pointerEvents: 'auto' }
                   : undefined,
                 tooltip: !isWritePermissions ? (
-                  <div>{t('cost_models.read_only_tooltip')}</div>
+                  <div>
+                    {intl.formatMessage({
+                      id: 'cost_models.read_only_tooltip',
+                    })}
+                  </div>
                 ) : (
                   undefined
                 ),
                 isDisabled: !isWritePermissions,
                 title: isWritePermissions ? (
                   <div style={{ color: 'red' }}>
-                    {t('cost_models_details.action_delete')}
+                    {intl.formatMessage({
+                      id: 'cost_models_details.action_delete',
+                    })}
                   </div>
                 ) : (
-                  t('cost_models_details.action_delete')
+                  intl.formatMessage({
+                    id: 'cost_models_details.action_delete',
+                  })
                 ),
                 onClick: (_evt, rowId) => {
                   this.setState({ rowId }, () => showDeleteDialog());
@@ -213,4 +240,4 @@ export default connect(
     setDialogOpen: costModelsActions.setCostModelDialog,
     deleteCostModel: costModelsActions.deleteCostModel,
   }
-)(translate()(CostModelsTable));
+)(injectIntl(CostModelsTable));

--- a/src/pages/costModels/costModelsDetails/emptyState.tsx
+++ b/src/pages/costModels/costModelsDetails/emptyState.tsx
@@ -8,40 +8,52 @@ import {
 } from '@patternfly/react-core';
 import { FileInvoiceDollarIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { isCostModelWritePermission } from 'store/rbac/selectors';
 import { ReadOnlyTooltip } from './components/readOnlyTooltip';
 import { styles } from './emptyState.styles';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   openModal: () => void;
   isWritePermission: boolean;
 }
 
 class NoSourcesStateBase extends React.Component<Props> {
   public render() {
-    const { t, openModal, isWritePermission } = this.props;
+    const { intl, openModal, isWritePermission } = this.props;
 
     return (
       <div style={styles.container}>
         <EmptyState>
           <EmptyStateIcon icon={FileInvoiceDollarIcon} />
-          <Title size="lg">{t('cost_models_details.empty_state.title')}</Title>
+          <Title size="lg">
+            {intl.formatMessage({
+              id: 'cost_models_details.empty_state.title',
+            })}
+          </Title>
           <EmptyStateBody>
-            <p>{t('cost_models_details.empty_state.desc')}</p>
+            <p>
+              {intl.formatMessage({
+                id: 'cost_models_details.empty_state.desc',
+              })}
+            </p>
           </EmptyStateBody>
           {isWritePermission && (
             <Button variant="primary" onClick={openModal}>
-              {t('cost_models_details.empty_state.primary_action')}
+              {intl.formatMessage({
+                id: 'cost_models_details.empty_state.primary_action',
+              })}
             </Button>
           )}
           {!isWritePermission && (
             <EmptyStateSecondaryActions>
               <ReadOnlyTooltip isDisabled>
                 <Button isDisabled>
-                  {t('cost_models_details.empty_state.primary_action')}
+                  {intl.formatMessage({
+                    id: 'cost_models_details.empty_state.primary_action',
+                  })}
                 </Button>
               </ReadOnlyTooltip>
             </EmptyStateSecondaryActions>
@@ -56,4 +68,4 @@ export default connect(
   createMapStateToProps(state => ({
     isWritePermission: isCostModelWritePermission(state),
   }))
-)(translate()(NoSourcesStateBase));
+)(injectIntl(NoSourcesStateBase));

--- a/src/pages/costModels/costModelsDetails/filterResults.tsx
+++ b/src/pages/costModels/costModelsDetails/filterResults.tsx
@@ -5,9 +5,9 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   onRemoveAll: () => void;
   onRemove: (name: string, value: string) => void;
   count: number;
@@ -28,7 +28,7 @@ class FilterResultsBase extends React.Component<Props> {
     return false;
   }
   public render() {
-    const { t, onRemoveAll, onRemove, count, filterQuery } = this.props;
+    const { intl, onRemoveAll, onRemove, count, filterQuery } = this.props;
     const filters = Object.keys(filterQuery)
       .filter(k => ['name', 'type'].includes(k))
       .filter(k => filterQuery[k])
@@ -40,14 +40,21 @@ class FilterResultsBase extends React.Component<Props> {
       <React.Fragment>
         <ToolbarGroup>
           <ToolbarItem>
-            <h5>{t('source_details.filter.results.count', { count })}</h5>
+            <h5>
+              {intl.formatMessage(
+                { id: 'source_details.filter.results.count' },
+                { count }
+              )}
+            </h5>
           </ToolbarItem>
         </ToolbarGroup>
         {filters.length > 0 && (
           <React.Fragment>
             <ToolbarGroup>
               <ToolbarItem>
-                {t('source_details.filter.results.active')}
+                {intl.formatMessage({
+                  id: 'source_details.filter.results.active',
+                })}
               </ToolbarItem>
             </ToolbarGroup>
             <ToolbarGroup>
@@ -60,7 +67,10 @@ class FilterResultsBase extends React.Component<Props> {
                       onRemove(f.name, f.value);
                     }}
                   >
-                    {t(`source_details.filter.results.${f.name}`)}: {f.value}
+                    {intl.formatMessage({
+                      id: `source_details.filter.results.${f.name}`,
+                    })}
+                    : {f.value}
                   </Chip>
                 ))}
               </ToolbarItem>
@@ -68,7 +78,9 @@ class FilterResultsBase extends React.Component<Props> {
             <ToolbarGroup>
               <ToolbarItem>
                 <Button onClick={onRemoveAll} variant="plain">
-                  {t('source_details.filter.results.clear')}
+                  {intl.formatMessage({
+                    id: 'source_details.filter.results.clear',
+                  })}
                 </Button>
               </ToolbarItem>
             </ToolbarGroup>
@@ -79,4 +91,4 @@ class FilterResultsBase extends React.Component<Props> {
   }
 }
 
-export default translate()(FilterResultsBase);
+export default injectIntl(FilterResultsBase);

--- a/src/pages/costModels/costModelsDetails/filterToolbar.tsx
+++ b/src/pages/costModels/costModelsDetails/filterToolbar.tsx
@@ -5,10 +5,10 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import i18next from 'i18next';
 import React from 'react';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 
-interface Props {
+interface Props extends WrappedComponentProps {
   options: { [k: string]: string };
   selected: string;
   value: string;
@@ -35,12 +35,14 @@ class FilterToolbar extends React.Component<Props> {
   }
 
   public render() {
-    const { value, onChange, options, selected } = this.props;
+    const { value, onChange, options, selected, intl } = this.props;
     return (
       <ToolbarGroup>
         <ToolbarItem>
           <FormSelect
-            aria-label={i18next.t('source_details.filter.type_aria_label')}
+            aria-label={intl.formatMessage({
+              id: 'source_details.filter.type_aria_label',
+            })}
             value={selected}
             onChange={this.props.onChange('type')}
           >
@@ -56,9 +58,12 @@ class FilterToolbar extends React.Component<Props> {
         <ToolbarItem>
           <TextInput
             value={value}
-            placeholder={i18next.t('cost_models_details.filter.placeholder', {
-              value: selected,
-            })}
+            placeholder={intl.formatMessage(
+              { id: 'cost_models_details.filter.placeholder' },
+              {
+                value: selected,
+              }
+            )}
             id="costModelFilterValue"
             onKeyPress={this.checkEnter}
             onChange={onChange('value')}
@@ -69,4 +74,4 @@ class FilterToolbar extends React.Component<Props> {
   }
 }
 
-export default FilterToolbar;
+export default injectIntl(FilterToolbar);

--- a/src/pages/costModels/costModelsDetails/header.tsx
+++ b/src/pages/costModels/costModelsDetails/header.tsx
@@ -1,17 +1,21 @@
 import { Button, ButtonVariant, Popover, Title } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { InjectedTranslateProps } from 'react-i18next';
+import { WrappedComponentProps } from 'react-intl';
 import { styles } from './costModelsDetails.styles';
 
-const Header: React.SFC<InjectedTranslateProps> = ({ t }) => (
+const Header: React.SFC<WrappedComponentProps> = ({ intl }) => (
   <header style={styles.header}>
     <Title style={styles.title} size="2xl">
-      {t('cost_models_details.header.title')}
+      {intl.formatMessage({ id: 'cost_models_details.header.title' })}
       <Popover
-        aria-label={t('cost_models_details.header.sub')}
+        aria-label={intl.formatMessage({
+          id: 'cost_models_details.header.sub',
+        })}
         enableFlip
-        bodyContent={t('cost_models_details.header.sub')}
+        bodyContent={intl.formatMessage({
+          id: 'cost_models_details.header.sub',
+        })}
       >
         <Button variant={ButtonVariant.plain}>
           <InfoCircleIcon />

--- a/src/pages/costModels/costModelsDetails/review.tsx
+++ b/src/pages/costModels/costModelsDetails/review.tsx
@@ -8,12 +8,12 @@ import {
 import { CostModel } from 'api/costModels';
 import { Provider } from 'api/providers';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsSelectors } from 'store/costModels';
 
-interface ReviewDetailsProps extends InjectedTranslateProps {
+interface ReviewDetailsProps extends WrappedComponentProps {
   costModel: CostModel;
   checked: { [uuid: string]: { selected: boolean; meta: Provider } };
   updateApiError: string;
@@ -21,7 +21,7 @@ interface ReviewDetailsProps extends InjectedTranslateProps {
 }
 
 const ReviewDetails: React.SFC<ReviewDetailsProps> = ({
-  t,
+  intl,
   costModel,
   checked,
   updateApiError,
@@ -33,18 +33,24 @@ const ReviewDetails: React.SFC<ReviewDetailsProps> = ({
         <Alert variant="danger" title={`${updateApiError}`} />
       )}
       <Title size={TitleSize.md}>
-        {t('cost_models_details.add_source_desc')}
+        {intl.formatMessage({ id: 'cost_models_details.add_source_desc' })}
       </Title>
       <Grid>
         <GridItem span={4}>
-          {t('cost_models_wizard.general_info.name_label')}
+          {intl.formatMessage({
+            id: 'cost_models_wizard.general_info.name_label',
+          })}
         </GridItem>
         <GridItem span={8}>{costModel.name}</GridItem>
         <GridItem span={4}>
-          {t('cost_models_wizard.general_info.description_label')}
+          {intl.formatMessage({
+            id: 'cost_models_wizard.general_info.description_label',
+          })}
         </GridItem>
         <GridItem span={8}>{costModel.description}</GridItem>
-        <GridItem span={4}>{t('cost_models_wizard.steps.sources')}</GridItem>
+        <GridItem span={4}>
+          {intl.formatMessage({ id: 'cost_models_wizard.steps.sources' })}
+        </GridItem>
         <GridItem span={8}>
           {Object.keys(checked)
             .filter(uuid => checked[uuid].selected)
@@ -52,7 +58,8 @@ const ReviewDetails: React.SFC<ReviewDetailsProps> = ({
             .join(', ')}
         </GridItem>
       </Grid>
-      {isUpdateProcessing && t('cost_models_wizard.inprogress_message')}
+      {isUpdateProcessing &&
+        intl.formatMessage({ id: 'cost_models_wizard.inprogress_message' })}
     </>
   );
 };
@@ -64,4 +71,4 @@ export default connect(
       isUpdateProcessing: costModelsSelectors.updateProcessing(state),
     };
   })
-)(translate()(ReviewDetails));
+)(injectIntl(ReviewDetails));

--- a/src/pages/costModels/costModelsDetails/sourceTable.tsx
+++ b/src/pages/costModels/costModelsDetails/sourceTable.tsx
@@ -1,6 +1,6 @@
 import { CostModel, CostModelProvider, CostModelRequest } from 'api/costModels';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
@@ -8,7 +8,7 @@ import AddSourceWizard from './addSourceWizard';
 import Dialog from './components/dialog';
 import Table from './components/table';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   updateCostModel: typeof costModelsActions.updateCostModel;
   costModel: CostModel;
   sources: CostModelProvider[];
@@ -29,7 +29,7 @@ class SourceTableBase extends React.Component<Props, State> {
       isLoading,
       sources,
       costModel,
-      t,
+      intl,
       isDialogOpen,
     } = this.props;
     return (
@@ -58,10 +58,13 @@ class SourceTableBase extends React.Component<Props, State> {
         <Dialog
           isSmall
           isOpen={isDialogOpen.deleteSource}
-          title={t('dialog.delete_source_from_cost_model_title', {
-            source: this.state.dialogSource,
-            cost_model: costModel.name,
-          })}
+          title={intl.formatMessage(
+            { id: 'dialog.delete_source_from_cost_model_title' },
+            {
+              source: this.state.dialogSource,
+              cost_model: costModel.name,
+            }
+          )}
           onClose={() => {
             setDialogOpen({ name: 'deleteSource', isOpen: false });
             this.setState({ dialogSource: null });
@@ -84,20 +87,29 @@ class SourceTableBase extends React.Component<Props, State> {
               'deleteSource'
             );
           }}
-          body={t('dialog.delete_source_from_cost_model_body', {
-            source: this.state.dialogSource,
-            cost_model: costModel.name,
-          })}
-          actionText={t('dialog.deleteSource')}
+          body={
+            <>
+              {intl.formatMessage(
+                { id: 'dialog.delete_source_from_cost_model_body' },
+                {
+                  source: this.state.dialogSource,
+                  cost_model: costModel.name,
+                }
+              )}
+            </>
+          }
+          actionText={intl.formatMessage({ id: 'dialog.deleteSource' })}
         />
         <Table
-          onDeleteText={t('cost_models_details.action_unassign')}
+          onDeleteText={intl.formatMessage({
+            id: 'cost_models_details.action_unassign',
+          })}
           onDelete={item => {
             this.setState({ dialogSource: item[0] });
             setDialogOpen({ name: 'deleteSource', isOpen: true });
           }}
           onAdd={() => setDialogOpen({ name: 'addSource', isOpen: true })}
-          cells={[t('filter.name')]}
+          cells={[intl.formatMessage({ id: 'filter.name' })]}
           rows={sources.map(p => p.name)}
         />
       </>
@@ -105,13 +117,15 @@ class SourceTableBase extends React.Component<Props, State> {
   }
 }
 
-export default connect(
-  createMapStateToProps(state => ({
-    isLoading: costModelsSelectors.updateProcessing(state),
-    isDialogOpen: costModelsSelectors.isDialogOpen(state)('sources'),
-  })),
-  {
-    setDialogOpen: costModelsActions.setCostModelDialog,
-    updateCostModel: costModelsActions.updateCostModel,
-  }
-)(translate()(SourceTableBase));
+export default injectIntl(
+  connect(
+    createMapStateToProps(state => ({
+      isLoading: costModelsSelectors.updateProcessing(state),
+      isDialogOpen: costModelsSelectors.isDialogOpen(state)('sources'),
+    })),
+    {
+      setDialogOpen: costModelsActions.setCostModelDialog,
+      updateCostModel: costModelsActions.updateCostModel,
+    }
+  )(SourceTableBase)
+);

--- a/src/pages/costModels/createCostModelWizard/assignSourcesToolbar.tsx
+++ b/src/pages/costModels/createCostModelWizard/assignSourcesToolbar.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core/dist/esm/experimental';
 import { SearchIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { Omit } from 'react-redux';
 
 interface SearchInputProps {
@@ -52,7 +52,7 @@ const SearchInput: React.SFC<SearchInputProps> = ({
   );
 };
 
-interface AssignSourcesToolbarBaseProps extends InjectedTranslateProps {
+interface AssignSourcesToolbarBaseProps extends WrappedComponentProps {
   paginationProps: PaginationProps;
   searchInputProps: Omit<SearchInputProps, 'placeholder'>;
   filter: {
@@ -63,7 +63,7 @@ interface AssignSourcesToolbarBaseProps extends InjectedTranslateProps {
 }
 
 export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> = ({
-  t,
+  intl,
   searchInputProps,
   paginationProps,
   filter,
@@ -81,9 +81,9 @@ export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> 
             categoryName="name"
           >
             <SearchInput
-              placeholder={t(
-                'cost_models_wizard.source_table.filter_placeholder'
-              )}
+              placeholder={intl.formatMessage({
+                id: 'cost_models_wizard.source_table.filter_placeholder',
+              })}
               {...searchInputProps}
             />
           </DataToolbarFilter>
@@ -96,4 +96,4 @@ export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> 
   );
 };
 
-export const AssignSourcesToolbar = translate()(AssignSourcesToolbarBase);
+export const AssignSourcesToolbar = injectIntl(AssignSourcesToolbarBase);

--- a/src/pages/costModels/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/costModels/createCostModelWizard/generalInformation.tsx
@@ -10,11 +10,11 @@ import {
 } from '@patternfly/react-core';
 import { Form } from 'components/forms/form';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { CostModelContext } from './context';
 import { styles } from './wizard.styles';
 
-const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
+const GeneralInformation: React.SFC<WrappedComponentProps> = ({ intl }) => {
   const docLink =
     'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/using_cost_models/configuring-cost-models';
   return (
@@ -30,18 +30,24 @@ const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
         <Stack gutter="md">
           <StackItem>
             <Title size="xl">
-              {t('cost_models_wizard.general_info.title')}
+              {intl.formatMessage({
+                id: 'cost_models_wizard.general_info.title',
+              })}
             </Title>
           </StackItem>
           <StackItem>
             <a href={docLink} target="blank">
-              {t('cost_models_wizard.general_info.learn_more')}
+              {intl.formatMessage({
+                id: 'cost_models_wizard.general_info.learn_more',
+              })}
             </a>
           </StackItem>
           <StackItem>
             <Form style={styles.form}>
               <FormGroup
-                label={t('cost_models_wizard.general_info.name_label')}
+                label={intl.formatMessage({
+                  id: 'cost_models_wizard.general_info.name_label',
+                })}
                 isRequired
                 fieldId="name"
               >
@@ -55,7 +61,9 @@ const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
                 />
               </FormGroup>
               <FormGroup
-                label={t('cost_models_wizard.general_info.description_label')}
+                label={intl.formatMessage({
+                  id: 'cost_models_wizard.general_info.description_label',
+                })}
                 fieldId="description"
               >
                 <TextArea
@@ -68,7 +76,9 @@ const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
                 />
               </FormGroup>
               <FormGroup
-                label={t('cost_models_wizard.general_info.source_type_label')}
+                label={intl.formatMessage({
+                  id: 'cost_models_wizard.general_info.source_type_label',
+                })}
                 isRequired
                 fieldId="source-type"
               >
@@ -79,21 +89,28 @@ const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
                 >
                   <FormSelectOption
                     value=""
-                    label={t(
-                      'cost_models_wizard.general_info.source_type_empty_value_label'
-                    )}
+                    label={intl.formatMessage({
+                      id:
+                        'cost_models_wizard.general_info.source_type_empty_value_label',
+                    })}
                   />
                   <FormSelectOption
                     value="AWS"
-                    label={t('onboarding.type_options.aws')}
+                    label={intl.formatMessage({
+                      id: 'onboarding.type_options.aws',
+                    })}
                   />
                   <FormSelectOption
                     value="AZURE"
-                    label={t('onboarding.type_options.azure')}
+                    label={intl.formatMessage({
+                      id: 'onboarding.type_options.azure',
+                    })}
                   />
                   <FormSelectOption
                     value="OCP"
-                    label={t('onboarding.type_options.ocp')}
+                    label={intl.formatMessage({
+                      id: 'onboarding.type_options.ocp',
+                    })}
                   />
                 </FormSelect>
               </FormGroup>
@@ -105,4 +122,4 @@ const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
   );
 };
 
-export default translate()(GeneralInformation);
+export default injectIntl(GeneralInformation);

--- a/src/pages/costModels/createCostModelWizard/index.tsx
+++ b/src/pages/costModels/createCostModelWizard/index.tsx
@@ -4,7 +4,7 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { addCostModel } from 'api/costModels';
 import { MetricHash } from 'api/metrics';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions } from 'store/costModels';
@@ -14,7 +14,7 @@ import { CostModelContext } from './context';
 import { parseApiError } from './parseError';
 import { stepsHash, validatorsHash } from './steps';
 
-interface InternalWizardBaseProps extends InjectedTranslateProps {
+interface InternalWizardBaseProps extends WrappedComponentProps {
   isProcess: boolean;
   isSuccess: boolean;
   closeFnc: () => void;
@@ -31,7 +31,7 @@ interface InternalWizardBaseProps extends InjectedTranslateProps {
 }
 
 const InternalWizardBase: React.SFC<InternalWizardBaseProps> = ({
-  t,
+  intl,
   isProcess,
   isSuccess,
   closeFnc,
@@ -58,15 +58,15 @@ const InternalWizardBase: React.SFC<InternalWizardBaseProps> = ({
     current === 2 &&
     !validators[current - 1](context);
   if (current === steps.length && context.type !== '') {
-    newSteps[current - 1].nextButtonText = t(
-      'cost_models_wizard.review.create_button'
-    );
+    newSteps[current - 1].nextButtonText = intl.formatMessage({
+      id: 'cost_models_wizard.review.create_button',
+    });
   }
   return isOpen ? (
     <Wizard
       isOpen
-      title={t('cost_models_wizard.title')}
-      description={t('cost_models_wizard.description')}
+      title={intl.formatMessage({ id: 'cost_models_wizard.title' })}
+      description={intl.formatMessage({ id: 'cost_models_wizard.description' })}
       steps={newSteps}
       startAtStep={current}
       onNext={onMove}
@@ -105,7 +105,7 @@ const InternalWizardBase: React.SFC<InternalWizardBaseProps> = ({
   ) : null;
 };
 
-const InternalWizard = translate()(InternalWizardBase);
+const InternalWizard = injectIntl(InternalWizardBase);
 
 const defaultState = {
   step: 1,
@@ -173,7 +173,7 @@ interface State {
   isDialogOpen: boolean;
 }
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   isOpen: boolean;
   closeWizard: () => void;
   openWizard: () => void;
@@ -184,14 +184,14 @@ interface Props extends InjectedTranslateProps {
 class CostModelWizardBase extends React.Component<Props, State> {
   public state = defaultState;
   public render() {
-    const { metricsHash, t } = this.props;
+    const { metricsHash, intl } = this.props;
 
     const closeConfirmDialog = () => {
       this.setState({ isDialogOpen: false }, this.props.openWizard);
     };
     const CancelButton = (
       <Button key="cancel" variant="link" onClick={closeConfirmDialog}>
-        {t('cost_models_wizard.confirm.cancel')}
+        {intl.formatMessage({ id: 'cost_models_wizard.confirm.cancel' })}
       </Button>
     );
     const OkButton = (
@@ -200,7 +200,7 @@ class CostModelWizardBase extends React.Component<Props, State> {
         variant="primary"
         onClick={() => this.setState({ ...defaultState })}
       >
-        {t('cost_models_wizard.confirm.ok')}
+        {intl.formatMessage({ id: 'cost_models_wizard.confirm.ok' })}
       </Button>
     );
 
@@ -321,7 +321,7 @@ class CostModelWizardBase extends React.Component<Props, State> {
           }}
           isOpen={this.props.isOpen}
           onMove={curr => this.setState({ step: Number(curr.id) })}
-          steps={stepsHash(t)[this.state.type]}
+          steps={stepsHash(intl)[this.state.type]}
           current={this.state.step}
           validators={validatorsHash[this.state.type]}
           setError={errorMessage =>
@@ -345,7 +345,7 @@ class CostModelWizardBase extends React.Component<Props, State> {
           isFooterLeftAligned
           isOpen={this.state.isDialogOpen}
           isSmall
-          title={t('cost_models_wizard.confirm.title')}
+          title={intl.formatMessage({ id: 'cost_models_wizard.confirm.title' })}
           onClose={closeConfirmDialog}
           actions={[OkButton, CancelButton]}
         >
@@ -354,7 +354,11 @@ class CostModelWizardBase extends React.Component<Props, State> {
               <ExclamationTriangleIcon size="xl" color="orange" />
             </SplitItem>
             <SplitItem isFilled>
-              <div>{t('cost_models_wizard.confirm.message')}</div>
+              <div>
+                {intl.formatMessage({
+                  id: 'cost_models_wizard.confirm.message',
+                })}
+              </div>
             </SplitItem>
           </Split>
         </Modal>
@@ -363,9 +367,11 @@ class CostModelWizardBase extends React.Component<Props, State> {
   }
 }
 
-export const CostModelWizard = connect(
-  createMapStateToProps(state => ({
-    metricsHash: metricsSelectors.metrics(state),
-  })),
-  { fetch: costModelsActions.fetchCostModels }
-)(translate()(CostModelWizardBase));
+export const CostModelWizard = injectIntl(
+  connect(
+    createMapStateToProps(state => ({
+      metricsHash: metricsSelectors.metrics(state),
+    })),
+    { fetch: costModelsActions.fetchCostModels }
+  )(CostModelWizardBase)
+);

--- a/src/pages/costModels/createCostModelWizard/markup.tsx
+++ b/src/pages/costModels/createCostModelWizard/markup.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { Form } from 'components/forms/form';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { CostModelContext } from './context';
 
 interface MarkupValidationState {
@@ -20,7 +20,7 @@ interface MarkupValidationState {
 }
 
 class Markup extends React.Component<
-  InjectedTranslateProps,
+  WrappedComponentProps,
   MarkupValidationState
 > {
   public state = {
@@ -28,7 +28,7 @@ class Markup extends React.Component<
   };
 
   public render() {
-    const { t } = this.props;
+    const { intl } = this.props;
     const { isValid } = this.state;
 
     return (
@@ -37,23 +37,31 @@ class Markup extends React.Component<
           return (
             <Stack gutter="md">
               <StackItem>
-                <Title size="xl">{t('cost_models_wizard.markup.title')}</Title>
+                <Title size="xl">
+                  {intl.formatMessage({
+                    id: 'cost_models_wizard.markup.title',
+                  })}
+                </Title>
               </StackItem>
               <StackItem>
                 <TextContent>
                   <Text component={TextVariants.h6}>
-                    {t('cost_models_wizard.markup.sub_title')}
+                    {intl.formatMessage({
+                      id: 'cost_models_wizard.markup.sub_title',
+                    })}
                   </Text>
                 </TextContent>
               </StackItem>
               <StackItem>
                 <Form>
                   <FormGroup
-                    label={t('cost_models_wizard.markup.markup_label')}
+                    label={intl.formatMessage({
+                      id: 'cost_models_wizard.markup.markup_label',
+                    })}
                     fieldId="markup"
-                    helperTextInvalid={t(
-                      'cost_models_wizard.markup.invalid_markup_text'
-                    )}
+                    helperTextInvalid={intl.formatMessage({
+                      id: 'cost_models_wizard.markup.invalid_markup_text',
+                    })}
                     isValid={isValid}
                   >
                     <InputGroup style={{ width: '150px' }}>
@@ -88,4 +96,4 @@ class Markup extends React.Component<
   }
 }
 
-export default translate()(Markup);
+export default injectIntl(Markup);

--- a/src/pages/costModels/createCostModelWizard/priceListTable.tsx
+++ b/src/pages/costModels/createCostModelWizard/priceListTable.tsx
@@ -22,14 +22,18 @@ import { PriceListToolbar } from 'pages/costModels/components/priceListToolbar';
 import { CheckboxSelector } from 'pages/costModels/components/toolbar/checkboxSelector';
 import { PrimarySelector } from 'pages/costModels/components/toolbar/primarySelector';
 import React from 'react';
-import { InjectedTranslateProps, Interpolate, translate } from 'react-i18next';
+import {
+  FormattedMessage,
+  injectIntl,
+  WrappedComponentProps,
+} from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { metricsSelectors } from 'store/metrics';
 import { RateTable } from '../components/rateTable';
 import { CostModelContext } from './context';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   metricsHash: MetricHash;
   maxRate: number;
   addRateAction: () => void;
@@ -37,25 +41,41 @@ interface Props extends InjectedTranslateProps {
   deleteRateAction: (data: TierData) => void;
 }
 
-const NoTiersEmptyState = ({ t }) => (
+const NoTiersEmptyState = ({ intl }) => (
   <Bullseye>
     <EmptyState>
       <EmptyStateIcon icon={PlusCircleIcon} />
-      <Title size="lg">{t('cost_models_wizard.empty_state.title')}</Title>
+      <Title size="lg">
+        {intl.formatMessage({ id: 'cost_models_wizard.empty_state.title' })}
+      </Title>
       <EmptyStateBody>
-        <Interpolate
-          i18nKey="cost_models_wizard.empty_state.desc_create"
-          add_rate={
-            <strong>{t('cost_models_wizard.empty_state.add_rate')}</strong>
-          }
+        <FormattedMessage
+          id="cost_models_wizard.empty_state.desc_create"
+          values={{
+            add_rate: (
+              <strong>
+                {intl.formatMessage({
+                  id: 'cost_models_wizard.empty_state.add_rate',
+                })}
+              </strong>
+            ),
+          }}
         />
         <br />
-        <Interpolate
-          i18nKey="cost_models_wizard.empty_state.desc_skip"
-          next={<strong>{t('cost_models_wizard.empty_state.next')}</strong>}
+        <FormattedMessage
+          id="cost_models_wizard.empty_state.desc_skip"
+          values={{
+            next: (
+              <strong>
+                {intl.formatMessage({
+                  id: 'cost_models_wizard.empty_state.next',
+                })}
+              </strong>
+            ),
+          }}
         />
         <br />
-        <Interpolate i18nKey="cost_models_wizard.empty_state.desc_other_time" />
+        <FormattedMessage id="cost_models_wizard.empty_state.desc_other_time" />
       </EmptyStateBody>
     </EmptyState>
   </Bullseye>
@@ -71,20 +91,23 @@ class PriceListTable extends React.Component<Props, State> {
   public render() {
     const {
       metricsHash,
-      t,
+      intl,
       maxRate,
       addRateAction,
       deleteRateAction,
       items,
     } = this.props;
     const metricOpts = Object.keys(metricsHash).map(m => ({
-      label: t(`cost_models.${m}`),
+      label: intl.formatMessage({ id: `cost_models.${m}` }),
       value: m,
     }));
     const measurementOpts = metricOpts.reduce((acc, curr) => {
       const measurs = Object.keys(metricsHash[curr.value])
         .filter(m => !acc.map(i => i.value).includes(m))
-        .map(m => ({ label: t(`toolbar.pricelist.options.${m}`), value: m }));
+        .map(m => ({
+          label: intl.formatMessage({ id: `toolbar.pricelist.options.${m}` }),
+          value: m,
+        }));
       return [...acc, ...measurs];
     }, []);
     return (
@@ -94,13 +117,17 @@ class PriceListTable extends React.Component<Props, State> {
             <Stack gutter="md">
               <StackItem>
                 <Title size={TitleSize.xl}>
-                  {t('cost_models_wizard.price_list.title')}
+                  {intl.formatMessage({
+                    id: 'cost_models_wizard.price_list.title',
+                  })}
                 </Title>
               </StackItem>
               <StackItem>
                 <TextContent>
                   <Text component={TextVariants.h6}>
-                    {t('cost_models_wizard.price_list.sub_title_table')}
+                    {intl.formatMessage({
+                      id: 'cost_models_wizard.price_list.sub_title_table',
+                    })}
                   </Text>
                 </TextContent>
               </StackItem>
@@ -142,11 +169,15 @@ class PriceListTable extends React.Component<Props, State> {
                               }
                               options={[
                                 {
-                                  label: t('toolbar.pricelist.metric'),
+                                  label: intl.formatMessage({
+                                    id: 'toolbar.pricelist.metric',
+                                  }),
                                   value: 'metrics',
                                 },
                                 {
-                                  label: t('toolbar.pricelist.measurement'),
+                                  label: intl.formatMessage({
+                                    id: 'toolbar.pricelist.measurement',
+                                  }),
                                   value: 'measurements',
                                 },
                               ]}
@@ -158,9 +189,10 @@ class PriceListTable extends React.Component<Props, State> {
                               component: (
                                 <CheckboxSelector
                                   isDisabled={items.length === 0}
-                                  placeholderText={t(
-                                    'toolbar.pricelist.measurement_placeholder'
-                                  )}
+                                  placeholderText={intl.formatMessage({
+                                    id:
+                                      'toolbar.pricelist.measurement_placeholder',
+                                  })}
                                   selections={search.measurements}
                                   setSelections={(selection: string) =>
                                     onSelect('measurements', selection)
@@ -176,9 +208,9 @@ class PriceListTable extends React.Component<Props, State> {
                               component: (
                                 <CheckboxSelector
                                   isDisabled={items.length === 0}
-                                  placeholderText={t(
-                                    'toolbar.pricelist.metric_placeholder'
-                                  )}
+                                  placeholderText={intl.formatMessage({
+                                    id: 'toolbar.pricelist.metric_placeholder',
+                                  })}
                                   selections={search.metrics}
                                   setSelections={(selection: string) =>
                                     onSelect('metrics', selection)
@@ -196,7 +228,9 @@ class PriceListTable extends React.Component<Props, State> {
                               isDisabled={maxRate === items.length}
                               onClick={addRateAction}
                             >
-                              {t('toolbar.pricelist.add_rate')}
+                              {intl.formatMessage({
+                                id: 'toolbar.pricelist.add_rate',
+                              })}
                             </Button>
                           }
                           onClear={onClearAll}
@@ -221,21 +255,22 @@ class PriceListTable extends React.Component<Props, State> {
                             this.state.measurements.length !== 0) && (
                             <Bullseye>
                               <EmptyFilterState
-                                filter={t(
-                                  'cost_models_wizard.price_list.toolbar_top_results_aria_label'
-                                )}
+                                filter={intl.formatMessage({
+                                  id:
+                                    'cost_models_wizard.price_list.toolbar_top_results_aria_label',
+                                })}
                               />
                             </Bullseye>
                           )}
                         {res.length === 0 &&
                           this.state.metrics.length === 0 &&
                           this.state.measurements.length === 0 && (
-                            <NoTiersEmptyState t={t} />
+                            <NoTiersEmptyState intl={intl} />
                           )}
                         {res.length > 0 && (
                           <RateTable
                             isCompact
-                            t={t}
+                            intl={intl}
                             tiers={res}
                             actions={[
                               {
@@ -265,4 +300,4 @@ export default connect(
     metricsHash: metricsSelectors.metrics(state),
     maxRate: metricsSelectors.maxRate(state),
   }))
-)(translate()(PriceListTable));
+)(injectIntl(PriceListTable));

--- a/src/pages/costModels/createCostModelWizard/review.tsx
+++ b/src/pages/costModels/createCostModelWizard/review.tsx
@@ -20,26 +20,37 @@ import {
 import { OkIcon } from '@patternfly/react-icons';
 import { WarningIcon } from 'pages/costModels/components/warningIcon';
 import React from 'react';
-import { InjectedTranslateProps, Interpolate, translate } from 'react-i18next';
+import {
+  FormattedMessage,
+  injectIntl,
+  WrappedComponentProps,
+} from 'react-intl';
 import { RateTable } from '../components/rateTable';
 import { CostModelContext } from './context';
 
-const ReviewSuccessBase: React.SFC<InjectedTranslateProps> = ({ t }) => (
+const ReviewSuccessBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
   <CostModelContext.Consumer>
     {({ onClose, name }) => (
       <EmptyState>
         <EmptyStateIcon icon={OkIcon} color="green" />
         <Title size={TitleSize.lg}>
-          {t('cost_models_wizard.review.title_success')}
+          {intl.formatMessage({
+            id: 'cost_models_wizard.review.title_success',
+          })}
         </Title>
         <EmptyStateBody>
-          {t('cost_models_wizard.review.sub_title_success', {
-            cost_model: name,
-          })}
+          {intl.formatMessage(
+            { id: 'cost_models_wizard.review.sub_title_success' },
+            {
+              cost_model: name,
+            }
+          )}
         </EmptyStateBody>
         <EmptyStateSecondaryActions>
           <Button variant="link" onClick={onClose}>
-            {t('cost_models_wizard.review.close_button')}
+            {intl.formatMessage({
+              id: 'cost_models_wizard.review.close_button',
+            })}
           </Button>
         </EmptyStateSecondaryActions>
       </EmptyState>
@@ -47,9 +58,9 @@ const ReviewSuccessBase: React.SFC<InjectedTranslateProps> = ({ t }) => (
   </CostModelContext.Consumer>
 );
 
-const ReviewSuccess = translate()(ReviewSuccessBase);
+const ReviewSuccess = injectIntl(ReviewSuccessBase);
 
-const ReviewDetailsBase: React.SFC<InjectedTranslateProps> = ({ t }) => (
+const ReviewDetailsBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
   <CostModelContext.Consumer>
     {({ name, description, type, markup, sources, tiers, createError }) => {
       return (
@@ -58,18 +69,32 @@ const ReviewDetailsBase: React.SFC<InjectedTranslateProps> = ({ t }) => (
           <Stack gutter="md">
             <StackItem>
               <Title size={TitleSize.xl}>
-                {t('cost_models_wizard.review.title_details')}
+                {intl.formatMessage({
+                  id: 'cost_models_wizard.review.title_details',
+                })}
               </Title>
             </StackItem>
             <StackItem>
               <TextContent>
                 <Text component={TextVariants.h6}>
-                  <Interpolate
-                    i18nKey="cost_models_wizard.review.sub_title_details"
-                    create={
-                      <b>{t('cost_models_wizard.review.create_button')}</b>
-                    }
-                    back={<b>{t('cost_models_wizard.review.back_button')}</b>}
+                  <FormattedMessage
+                    id="cost_models_wizard.review.sub_title_details"
+                    values={{
+                      create: (
+                        <b>
+                          {intl.formatMessage({
+                            id: 'cost_models_wizard.review.create_button',
+                          })}
+                        </b>
+                      ),
+                      back: (
+                        <b>
+                          {intl.formatMessage({
+                            id: 'cost_models_wizard.review.back_button',
+                          })}
+                        </b>
+                      ),
+                    }}
                   />
                 </Text>
               </TextContent>
@@ -78,13 +103,17 @@ const ReviewDetailsBase: React.SFC<InjectedTranslateProps> = ({ t }) => (
               <TextContent>
                 <TextList component={TextListVariants.dl}>
                   <TextListItem component={TextListItemVariants.dt}>
-                    {t('cost_models_wizard.general_info.name_label')}
+                    {intl.formatMessage({
+                      id: 'cost_models_wizard.general_info.name_label',
+                    })}
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>
                     {name}
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dt}>
-                    {t('cost_models_wizard.general_info.description_label')}
+                    {intl.formatMessage({
+                      id: 'cost_models_wizard.general_info.description_label',
+                    })}
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>
                     {description}
@@ -92,30 +121,41 @@ const ReviewDetailsBase: React.SFC<InjectedTranslateProps> = ({ t }) => (
                   {type === 'OCP' && (
                     <>
                       <TextListItem component={TextListItemVariants.dt}>
-                        {t('cost_models_wizard.steps.price_list')}
+                        {intl.formatMessage({
+                          id: 'cost_models_wizard.steps.price_list',
+                        })}
                       </TextListItem>
                       <TextListItem component={TextListItemVariants.dd}>
                         {tiers.length > 0 ? (
-                          <RateTable t={t} tiers={tiers} />
+                          <RateTable intl={intl} tiers={tiers} />
                         ) : (
-                          t('cost_models_wizard.no_rates')
+                          intl.formatMessage({
+                            id: 'cost_models_wizard.no_rates',
+                          })
                         )}
                       </TextListItem>
                     </>
                   )}
                   <TextListItem component={TextListItemVariants.dt}>
-                    {t('cost_models_wizard.review.markup')}
+                    {intl.formatMessage({
+                      id: 'cost_models_wizard.review.markup',
+                    })}
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>
                     {markup}%
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dt}>
-                    {t('cost_models_wizard.review.sources')}{' '}
+                    {intl.formatMessage({
+                      id: 'cost_models_wizard.review.sources',
+                    })}{' '}
+                    }
                     {sources.find(
                       src => src.selected && Boolean(src.costmodel)
                     ) && (
                       <WarningIcon
-                        text={t('cost_models_wizard.warning_override_sources')}
+                        text={intl.formatMessage({
+                          id: 'cost_models_wizard.warning_override_sources',
+                        })}
                       />
                     )}
                   </TextListItem>
@@ -135,7 +175,7 @@ const ReviewDetailsBase: React.SFC<InjectedTranslateProps> = ({ t }) => (
   </CostModelContext.Consumer>
 );
 
-const ReviewDetails = translate()(ReviewDetailsBase);
+const ReviewDetails = injectIntl(ReviewDetailsBase);
 
 const Review = () => {
   return (

--- a/src/pages/costModels/createCostModelWizard/steps.tsx
+++ b/src/pages/costModels/createCostModelWizard/steps.tsx
@@ -1,86 +1,87 @@
 import React from 'react';
+import { IntlShape } from 'react-intl';
 import GeneralInformation from './generalInformation';
 import Markup from './markup';
 import PriceList from './priceList';
 import Review from './review';
 import Sources from './sources';
 
-export const stepsHash = (t: (text: string) => string) => ({
+export const stepsHash = (intl: IntlShape) => ({
   '': [
     {
       id: 1,
-      name: t('cost_models_wizard.steps.general_info'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.general_info' }),
       component: <GeneralInformation />,
     },
   ],
   AZURE: [
     {
       id: 1,
-      name: t('cost_models_wizard.steps.general_info'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.general_info' }),
       component: <GeneralInformation />,
     },
     {
       id: 2,
-      name: t('cost_models_wizard.steps.markup'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.markup' }),
       component: <Markup />,
     },
     {
       id: 3,
-      name: t('cost_models_wizard.steps.sources'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.sources' }),
       component: <Sources />,
     },
     {
       id: 4,
-      name: t('cost_models_wizard.steps.review'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.review' }),
       component: <Review />,
     },
   ],
   AWS: [
     {
       id: 1,
-      name: t('cost_models_wizard.steps.general_info'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.general_info' }),
       component: <GeneralInformation />,
     },
     {
       id: 2,
-      name: t('cost_models_wizard.steps.markup'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.markup' }),
       component: <Markup />,
     },
     {
       id: 3,
-      name: t('cost_models_wizard.steps.sources'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.sources' }),
       component: <Sources />,
     },
     {
       id: 4,
-      name: t('cost_models_wizard.steps.review'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.review' }),
       component: <Review />,
     },
   ],
   OCP: [
     {
       id: 1,
-      name: t('cost_models_wizard.steps.general_info'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.general_info' }),
       component: <GeneralInformation />,
     },
     {
       id: 2,
-      name: t('cost_models_wizard.steps.price_list'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.price_list' }),
       component: <PriceList />,
     },
     {
       id: 3,
-      name: t('cost_models_wizard.steps.markup'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.markup' }),
       component: <Markup />,
     },
     {
       id: 4,
-      name: t('cost_models_wizard.steps.sources'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.sources' }),
       component: <Sources />,
     },
     {
       id: 5,
-      name: t('cost_models_wizard.steps.review'),
+      name: intl.formatMessage({ id: 'cost_models_wizard.steps.review' }),
       component: <Review />,
     },
   ],

--- a/src/pages/costModels/createCostModelWizard/table.tsx
+++ b/src/pages/costModels/createCostModelWizard/table.tsx
@@ -19,11 +19,11 @@ import {
 } from 'pages/costModels/components/filterLogic';
 import { WarningIcon } from 'pages/costModels/components/warningIcon';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { AssignSourcesToolbar } from './assignSourcesToolbar';
 import { CostModelContext } from './context';
 
-const SourcesTable: React.SFC<InjectedTranslateProps> = ({ t }) => {
+const SourcesTable: React.SFC<WrappedComponentProps> = ({ intl }) => {
   return (
     <CostModelContext.Consumer>
       {({
@@ -43,22 +43,31 @@ const SourcesTable: React.SFC<InjectedTranslateProps> = ({ t }) => {
           <Stack gutter="md">
             <StackItem>
               <Title size="xl">
-                {t(`cost_models_wizard.source.title_${type}`)}
+                {intl.formatMessage({
+                  id: `cost_models_wizard.source.title_${type}`,
+                })}
               </Title>
             </StackItem>
             <StackItem>
               <TextContent>
                 <Text component={TextVariants.h6}>
-                  {t('cost_models_wizard.source.sub_title')}
+                  {intl.formatMessage({
+                    id: 'cost_models_wizard.source.sub_title',
+                  })}
                 </Text>
               </TextContent>
             </StackItem>
             <StackItem>
               <TextContent>
                 <Text component={TextVariants.h3}>
-                  {t('cost_models_wizard.source.caption', {
-                    type: t(`source_details.type.${type}`),
-                  })}
+                  {intl.formatMessage(
+                    { id: 'cost_models_wizard.source.caption' },
+                    {
+                      type: intl.formatMessage({
+                        id: `source_details.type.${type}`,
+                      }),
+                    }
+                  )}
                 </Text>
               </TextContent>
             </StackItem>
@@ -104,12 +113,16 @@ const SourcesTable: React.SFC<InjectedTranslateProps> = ({ t }) => {
                 <LoadingState />
               ) : (
                 <Table
-                  aria-label={t(
-                    'cost_models_wizard.source_table.table_aria_label'
-                  )}
+                  aria-label={intl.formatMessage({
+                    id: 'cost_models_wizard.source_table.table_aria_label',
+                  })}
                   cells={[
-                    t('cost_models_wizard.source_table.column_name'),
-                    t('cost_models_wizard.source_table.column_cost_model'),
+                    intl.formatMessage({
+                      id: 'cost_models_wizard.source_table.column_name',
+                    }),
+                    intl.formatMessage({
+                      id: 'cost_models_wizard.source_table.column_cost_model',
+                    }),
                   ]}
                   onSelect={(_evt, isSelected, rowId) =>
                     onSourceSelect(rowId, isSelected)
@@ -122,8 +135,11 @@ const SourcesTable: React.SFC<InjectedTranslateProps> = ({ t }) => {
                           {r.selected && Boolean(r.costmodel) && (
                             <WarningIcon
                               key={`wrng-${r.name}`}
-                              text={t(
-                                'cost_models_wizard.warning_override_source',
+                              text={intl.formatMessage(
+                                {
+                                  id:
+                                    'cost_models_wizard.warning_override_source',
+                                },
                                 { cost_model: r.costmodel }
                               )}
                             />
@@ -131,9 +147,10 @@ const SourcesTable: React.SFC<InjectedTranslateProps> = ({ t }) => {
                         </>,
                         Boolean(r.costmodel)
                           ? r.costmodel
-                          : t(
-                              'cost_models_wizard.source_table.default_cost_model'
-                            ),
+                          : intl.formatMessage({
+                              id:
+                                'cost_models_wizard.source_table.default_cost_model',
+                            }),
                       ],
                       selected: r.selected,
                     };
@@ -145,9 +162,10 @@ const SourcesTable: React.SFC<InjectedTranslateProps> = ({ t }) => {
               )}
               <DataToolbar id="costmodels_wizard_datatoolbar">
                 <DataToolbarContent
-                  aria-label={t(
-                    'cost_models_wizard.source_table.pagination_section_aria_label'
-                  )}
+                  aria-label={intl.formatMessage({
+                    id:
+                      'cost_models_wizard.source_table.pagination_section_aria_label',
+                  })}
                 >
                   <DataToolbarGroup style={{ marginLeft: 'auto' }}>
                     <DataToolbarItem>
@@ -175,4 +193,4 @@ const SourcesTable: React.SFC<InjectedTranslateProps> = ({ t }) => {
   );
 };
 
-export default translate()(SourcesTable);
+export default injectIntl(SourcesTable);

--- a/src/pages/dashboard/awsCloudDashboard/awsCloudDashboard.tsx
+++ b/src/pages/dashboard/awsCloudDashboard/awsCloudDashboard.tsx
@@ -1,11 +1,11 @@
 import { DashboardBase } from 'pages/dashboard/components/dashboardBase';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { awsCloudDashboardSelectors } from 'store/dashboard/awsCloudDashboard';
 import { AwsCloudDashboardWidget } from './awsCloudDashboardWidget';
 
-type AwsCloudDashboardOwnProps = InjectedTranslateProps;
+type AwsCloudDashboardOwnProps = WrappedComponentProps;
 
 interface AwsCloudDashboardStateProps {
   DashboardWidget: typeof AwsCloudDashboardWidget;
@@ -23,7 +23,7 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const AwsCloudDashboard = translate()(
+const AwsCloudDashboard = injectIntl(
   connect(mapStateToProps, {})(DashboardBase)
 );
 

--- a/src/pages/dashboard/awsCloudDashboard/awsCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/awsCloudDashboard/awsCloudDashboardWidget.tsx
@@ -3,7 +3,6 @@ import {
   DashboardWidgetOwnProps,
   DashboardWidgetStateProps,
 } from 'pages/dashboard/components/dashboardWidgetBase';
-import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import {
@@ -87,8 +86,9 @@ const mapDispatchToProps: AwsCloudDashboardWidgetDispatchProps = {
   updateTab: awsCloudDashboardActions.changeWidgetTab,
 };
 
-const AwsCloudDashboardWidget = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(DashboardWidgetBase)
-);
+const AwsCloudDashboardWidget = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DashboardWidgetBase);
 
 export { AwsCloudDashboardWidget };

--- a/src/pages/dashboard/awsDashboard/awsDashboard.tsx
+++ b/src/pages/dashboard/awsDashboard/awsDashboard.tsx
@@ -1,11 +1,11 @@
 import { DashboardBase } from 'pages/dashboard/components/dashboardBase';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { awsDashboardSelectors } from 'store/dashboard/awsDashboard';
 import { AwsDashboardWidget } from './awsDashboardWidget';
 
-type AwsDashboardOwnProps = InjectedTranslateProps;
+type AwsDashboardOwnProps = WrappedComponentProps;
 
 interface AwsDashboardStateProps {
   DashboardWidget: typeof AwsDashboardWidget;
@@ -23,6 +23,6 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const AwsDashboard = translate()(connect(mapStateToProps, {})(DashboardBase));
+const AwsDashboard = injectIntl(connect(mapStateToProps, {})(DashboardBase));
 
 export default AwsDashboard;

--- a/src/pages/dashboard/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/dashboard/awsDashboard/awsDashboardWidget.tsx
@@ -3,7 +3,6 @@ import {
   DashboardWidgetOwnProps,
   DashboardWidgetStateProps,
 } from 'pages/dashboard/components/dashboardWidgetBase';
-import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import {
@@ -84,8 +83,9 @@ const mapDispatchToProps: AwsDashboardWidgetDispatchProps = {
   updateTab: awsDashboardActions.changeWidgetTab,
 };
 
-const AwsDashboardWidget = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(DashboardWidgetBase)
-);
+const AwsDashboardWidget = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DashboardWidgetBase);
 
 export { AwsDashboardWidget };

--- a/src/pages/dashboard/azureCloudDashboard/azureCloudDashboard.tsx
+++ b/src/pages/dashboard/azureCloudDashboard/azureCloudDashboard.tsx
@@ -1,11 +1,11 @@
 import { DashboardBase } from 'pages/dashboard/components/dashboardBase';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { azureCloudDashboardSelectors } from 'store/dashboard/azureCloudDashboard';
 import { AzureCloudDashboardWidget } from './azureCloudDashboardWidget';
 
-type AzureCloudDashboardOwnProps = InjectedTranslateProps;
+type AzureCloudDashboardOwnProps = WrappedComponentProps;
 
 interface AzureCloudDashboardStateProps {
   DashboardWidget: typeof AzureCloudDashboardWidget;
@@ -23,7 +23,7 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const AzureCloudDashboard = translate()(
+const AzureCloudDashboard = injectIntl(
   connect(mapStateToProps, {})(DashboardBase)
 );
 

--- a/src/pages/dashboard/azureCloudDashboard/azureCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/azureCloudDashboard/azureCloudDashboardWidget.tsx
@@ -3,7 +3,6 @@ import {
   DashboardWidgetOwnProps,
   DashboardWidgetStateProps,
 } from 'pages/dashboard/components/dashboardWidgetBase';
-import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import {
@@ -87,8 +86,9 @@ const mapDispatchToProps: AzureCloudDashboardWidgetDispatchProps = {
   updateTab: azureCloudDashboardActions.changeWidgetTab,
 };
 
-const AzureCloudDashboardWidget = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(DashboardWidgetBase)
-);
+const AzureCloudDashboardWidget = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DashboardWidgetBase);
 
 export { AzureCloudDashboardWidget };

--- a/src/pages/dashboard/azureDashboard/azureDashboard.tsx
+++ b/src/pages/dashboard/azureDashboard/azureDashboard.tsx
@@ -1,11 +1,11 @@
 import { DashboardBase } from 'pages/dashboard/components/dashboardBase';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { azureDashboardSelectors } from 'store/dashboard/azureDashboard';
 import { AzureDashboardWidget } from './azureDashboardWidget';
 
-type AzureDashboardOwnProps = InjectedTranslateProps;
+type AzureDashboardOwnProps = WrappedComponentProps;
 
 interface AzureDashboardStateProps {
   DashboardWidget: typeof AzureDashboardWidget;
@@ -23,6 +23,6 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const AzureDashboard = translate()(connect(mapStateToProps, {})(DashboardBase));
+const AzureDashboard = injectIntl(connect(mapStateToProps, {})(DashboardBase));
 
 export default AzureDashboard;

--- a/src/pages/dashboard/azureDashboard/azureDashboardWidget.tsx
+++ b/src/pages/dashboard/azureDashboard/azureDashboardWidget.tsx
@@ -3,7 +3,6 @@ import {
   DashboardWidgetOwnProps,
   DashboardWidgetStateProps,
 } from 'pages/dashboard/components/dashboardWidgetBase';
-import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import {
@@ -84,8 +83,9 @@ const mapDispatchToProps: AzureDashboardWidgetDispatchProps = {
   updateTab: azureDashboardActions.changeWidgetTab,
 };
 
-const AzureDashboardWidget = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(DashboardWidgetBase)
-);
+const AzureDashboardWidget = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DashboardWidgetBase);
 
 export { AzureDashboardWidget };

--- a/src/pages/dashboard/components/dashboardBase.tsx
+++ b/src/pages/dashboard/components/dashboardBase.tsx
@@ -1,8 +1,8 @@
 import { Grid, GridItem } from '@patternfly/react-core';
 import React from 'react';
-import { InjectedTranslateProps } from 'react-i18next';
+import { WrappedComponentProps } from 'react-intl';
 
-type DashboardOwnProps = InjectedTranslateProps;
+type DashboardOwnProps = WrappedComponentProps;
 
 interface DashboardStateProps {
   DashboardWidget: any;

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -20,7 +20,7 @@ import getDate from 'date-fns/get_date';
 import getMonth from 'date-fns/get_month';
 import startOfMonth from 'date-fns/start_of_month';
 import React from 'react';
-import { InjectedTranslateProps } from 'react-i18next';
+import { WrappedComponentProps } from 'react-intl';
 import { Link } from 'react-router-dom';
 import {
   DashboardChartType,
@@ -55,7 +55,7 @@ interface DashboardWidgetDispatchProps {
 type DashboardWidgetProps = DashboardWidgetOwnProps &
   DashboardWidgetStateProps &
   DashboardWidgetDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   public state = {
@@ -111,10 +111,13 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     height: number,
     adjustContainerHeight: boolean = false
   ) => {
-    const { currentReport, previousReport, t, trend } = this.props;
+    const { currentReport, previousReport, intl, trend } = this.props;
 
     const units = this.getUnits();
-    const title = t(trend.titleKey, { units: t(`units.${units}`) });
+    const title = intl.formatMessage(
+      { id: trend.titleKey },
+      { units: intl.formatMessage({ id: `units.${units}` }) }
+    );
     const computedReportItem = trend.computedReportItem || 'cost'; // cost, supplementaryCost, etc.
     const computedReportItemValue = trend.computedReportItemValue || 'total';
 
@@ -173,10 +176,13 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     adjustContainerHeight: boolean = false,
     showSupplementaryLabel: boolean = false
   ) => {
-    const { currentReport, details, previousReport, t, trend } = this.props;
+    const { currentReport, details, previousReport, intl, trend } = this.props;
 
     const units = this.getUnits();
-    const title = t(trend.titleKey, { units: t(`units.${units}`) });
+    const title = intl.formatMessage(
+      { id: trend.titleKey },
+      { units: intl.formatMessage({ id: `units.${units}` }) }
+    );
     const computedReportItem = trend.computedReportItem || 'cost'; // cost, supplementaryCost, etc.
     const computedReportItemValue = trend.computedReportItemValue || 'total';
 
@@ -215,10 +221,13 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
   // This chart displays usage and requests
   private getUsageChart = (height: number) => {
-    const { currentReport, previousReport, t, trend } = this.props;
+    const { currentReport, previousReport, intl, trend } = this.props;
 
     const units = this.getUnits();
-    const title = t(trend.titleKey, { units: t(`units.${units}`) });
+    const title = intl.formatMessage(
+      { id: trend.titleKey },
+      { units: intl.formatMessage({ id: `units.${units}` }) }
+    );
 
     // Request data
     const currentRequestData = transformReport(
@@ -290,8 +299,13 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getDetailsLabel = (key: string, units: string) => {
-    const { t } = this.props;
-    return key ? t(key, { units: t(`units.${units}`) }) : undefined;
+    const { intl } = this.props;
+    return key
+      ? intl.formatMessage(
+          { id: key },
+          { units: intl.formatMessage({ id: `units.${units}` }) }
+        )
+      : undefined;
   };
 
   private getDetailsLink = () => {
@@ -311,10 +325,10 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getDetailsLinkTitle = <T extends DashboardWidget<any>>(tab: T) => {
-    const { getIdKeyForTab, t } = this.props;
+    const { getIdKeyForTab, intl } = this.props;
     const key = getIdKeyForTab(tab) || '';
 
-    return t('group_by.all', { groupBy: key });
+    return intl.formatMessage({ id: 'group_by.all' }, { groupBy: key });
   };
 
   private getHorizontalLayout = () => {
@@ -339,19 +353,22 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getSubTitle = () => {
-    const { t } = this.props;
+    const { intl } = this.props;
 
     const today = new Date();
     const month = getMonth(today);
     const endDate = formatDate(today, 'D');
     const startDate = formatDate(startOfMonth(today), 'D');
 
-    return t('aws_dashboard.widget_subtitle', {
-      count: getDate(today),
-      endDate,
-      month,
-      startDate,
-    });
+    return intl.formatMessage(
+      { id: 'aws_dashboard.widget_subtitle' },
+      {
+        count: getDate(today),
+        endDate,
+        month,
+        startDate,
+      }
+    );
   };
 
   private getTab = <T extends DashboardWidget<any>>(tab: T, index: number) => {
@@ -452,21 +469,21 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getTabTitle = <T extends DashboardWidget<any>>(tab: T) => {
-    const { getIdKeyForTab, t } = this.props;
+    const { getIdKeyForTab, intl } = this.props;
     const key = getIdKeyForTab(tab) || '';
 
-    return t('group_by.top', { groupBy: key });
+    return intl.formatMessage({ id: 'group_by.top' }, { groupBy: key });
   };
 
   private getTitle = () => {
-    const { t, titleKey } = this.props;
+    const { intl, titleKey } = this.props;
 
     const today = new Date();
     const month = getMonth(today);
     const endDate = formatDate(today, 'Do');
     const startDate = formatDate(startOfMonth(today), 'Do');
 
-    return t(titleKey, { endDate, month, startDate });
+    return intl.formatMessage({ id: titleKey }, { endDate, month, startDate });
   };
 
   private getUnits = () => {

--- a/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboard.tsx
+++ b/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboard.tsx
@@ -1,11 +1,11 @@
 import { DashboardBase } from 'pages/dashboard/components/dashboardBase';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { ocpCloudDashboardSelectors } from 'store/dashboard/ocpCloudDashboard';
 import { OcpCloudDashboardWidget } from './ocpCloudDashboardWidget';
 
-type OcpCloudDashboardOwnProps = InjectedTranslateProps;
+type OcpCloudDashboardOwnProps = WrappedComponentProps;
 
 interface OcpCloudDashboardStateProps {
   DashboardWidget: typeof OcpCloudDashboardWidget;
@@ -23,7 +23,7 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const OcpCloudDashboard = translate()(
+const OcpCloudDashboard = injectIntl(
   connect(mapStateToProps, {})(DashboardBase)
 );
 

--- a/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
@@ -3,7 +3,7 @@ import {
   DashboardWidgetOwnProps,
   DashboardWidgetStateProps,
 } from 'pages/dashboard/components/dashboardWidgetBase';
-import { translate } from 'react-i18next';
+import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import {
@@ -85,7 +85,7 @@ const mapDispatchToProps: OcpCloudDashboardWidgetDispatchProps = {
   updateTab: ocpCloudDashboardActions.changeWidgetTab,
 };
 
-const OcpCloudDashboardWidget = translate()(
+const OcpCloudDashboardWidget = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(DashboardWidgetBase)
 );
 

--- a/src/pages/dashboard/ocpDashboard/ocpDashboard.tsx
+++ b/src/pages/dashboard/ocpDashboard/ocpDashboard.tsx
@@ -1,11 +1,11 @@
 import { DashboardBase } from 'pages/dashboard/components/dashboardBase';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { ocpDashboardSelectors } from 'store/dashboard/ocpDashboard';
 import { OcpDashboardWidget } from './ocpDashboardWidget';
 
-type OcpDashboardOwnProps = InjectedTranslateProps;
+type OcpDashboardOwnProps = WrappedComponentProps;
 
 interface OcpDashboardStateProps {
   DashboardWidget: typeof OcpDashboardWidget;
@@ -23,6 +23,6 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const OcpDashboard = translate()(connect(mapStateToProps, {})(DashboardBase));
+const OcpDashboard = injectIntl(connect(mapStateToProps, {})(DashboardBase));
 
 export default OcpDashboard;

--- a/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.tsx
@@ -3,7 +3,7 @@ import {
   DashboardWidgetOwnProps,
   DashboardWidgetStateProps,
 } from 'pages/dashboard/components/dashboardWidgetBase';
-import { translate } from 'react-i18next';
+import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import {
@@ -85,7 +85,7 @@ const mapDispatchToProps: OcpDashboardWidgetDispatchProps = {
   updateTab: ocpDashboardActions.changeWidgetTab,
 };
 
-const OcpDashboardWidget = translate()(
+const OcpDashboardWidget = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(DashboardWidgetBase)
 );
 

--- a/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboard.tsx
+++ b/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboard.tsx
@@ -1,11 +1,11 @@
 import { DashboardBase } from 'pages/dashboard/components/dashboardBase';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { ocpSupplementaryDashboardSelectors } from 'store/dashboard/ocpSupplementaryDashboard';
 import { OcpSupplementaryDashboardWidget } from './ocpSupplementaryDashboardWidget';
 
-type OcpSupplementaryDashboardOwnProps = InjectedTranslateProps;
+type OcpSupplementaryDashboardOwnProps = WrappedComponentProps;
 
 interface OcpSupplementaryDashboardStateProps {
   widgets: number[];
@@ -21,7 +21,7 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const OcpSupplementaryDashboard = translate()(
+const OcpSupplementaryDashboard = injectIntl(
   connect(mapStateToProps, {})(DashboardBase)
 );
 

--- a/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.tsx
@@ -3,7 +3,7 @@ import {
   DashboardWidgetOwnProps,
   DashboardWidgetStateProps,
 } from 'pages/dashboard/components/dashboardWidgetBase';
-import { translate } from 'react-i18next';
+import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import {
@@ -88,7 +88,7 @@ const mapDispatchToProps: OcpSupplementaryDashboardWidgetDispatchProps = {
   updateTab: ocpSupplementaryDashboardActions.changeWidgetTab,
 };
 
-const OcpSupplementaryDashboardWidget = translate()(
+const OcpSupplementaryDashboardWidget = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(DashboardWidgetBase)
 );
 

--- a/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboard.tsx
+++ b/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboard.tsx
@@ -1,11 +1,11 @@
 import { DashboardBase } from 'pages/dashboard/components/dashboardBase';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { ocpUsageDashboardSelectors } from 'store/dashboard/ocpUsageDashboard';
 import { OcpUsageDashboardWidget } from './ocpUsageDashboardWidget';
 
-type OcpUsageDashboardOwnProps = InjectedTranslateProps;
+type OcpUsageDashboardOwnProps = WrappedComponentProps;
 
 interface OcpUsageDashboardStateProps {
   DashboardWidget: typeof OcpUsageDashboardWidget;
@@ -23,7 +23,7 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const OcpUsageDashboard = translate()(
+const OcpUsageDashboard = injectIntl(
   connect(mapStateToProps, {})(DashboardBase)
 );
 

--- a/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboardWidget.tsx
@@ -3,7 +3,7 @@ import {
   DashboardWidgetOwnProps,
   DashboardWidgetStateProps,
 } from 'pages/dashboard/components/dashboardWidgetBase';
-import { translate } from 'react-i18next';
+// import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import {
@@ -85,8 +85,9 @@ const mapDispatchToProps: OcpUsageDashboardWidgetDispatchProps = {
   updateTab: ocpUsageDashboardActions.changeWidgetTab,
 };
 
-const OcpUsageDashboardWidget = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(DashboardWidgetBase)
-);
+const OcpUsageDashboardWidget = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DashboardWidgetBase);
 
 export { OcpUsageDashboardWidget };

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -16,7 +16,7 @@ import { LoadingState } from 'components/state/loadingState/loadingState';
 import { NoProvidersState } from 'components/state/noProvidersState/noProvidersState';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -54,7 +54,7 @@ interface AwsDetailsState {
   selectedItems: ComputedReportItem[];
 }
 
-type AwsDetailsOwnProps = RouteComponentProps<void> & InjectedTranslateProps;
+type AwsDetailsOwnProps = RouteComponentProps<void> & WrappedComponentProps;
 
 type AwsDetailsProps = AwsDetailsStateProps &
   AwsDetailsOwnProps &
@@ -511,6 +511,6 @@ const mapDispatchToProps: AwsDetailsDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-export default translate()(
+export default injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(AwsDetails)
 );

--- a/src/pages/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/details/awsDetails/detailsHeader.tsx
@@ -11,7 +11,7 @@ import {
   TertiaryNavItem,
 } from 'pages/details/components/nav/tertiaryNav';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { awsProvidersQuery, providersSelectors } from 'store/providers';
@@ -38,7 +38,7 @@ interface DetailsHeaderStateProps {
 
 type DetailsHeaderProps = DetailsHeaderOwnProps &
   DetailsHeaderStateProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const baseQuery: AwsQuery = {
   delta: 'cost',
@@ -68,7 +68,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers,
       providersError,
       report,
-      t,
+      intl,
     } = this.props;
     const showContent =
       report &&
@@ -88,7 +88,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       <header style={styles.header}>
         <div>
           <Title style={styles.title} size={TitleSize['2xl']}>
-            {t('navigation.infrastructure_details')}
+            {intl.formatMessage({ id: 'navigation.infrastructure_details' })}
           </Title>
           <div style={styles.nav}>
             <TertiaryNav activeItem={TertiaryNavItem.aws} />
@@ -109,7 +109,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             </Title>
             <div style={styles.costLabel}>
               <div style={styles.costLabelUnit}>
-                {t('aws_details.total_cost')}
+                {intl.formatMessage({ id: 'aws_details.total_cost' })}
               </div>
               <div style={styles.costLabelDate}>
                 {getSinceDateRangeString()}
@@ -152,7 +152,7 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const DetailsHeader = translate()(
+const DetailsHeader = injectIntl(
   connect(mapStateToProps, {})(DetailsHeaderBase)
 );
 

--- a/src/pages/details/awsDetails/detailsSummary.tsx
+++ b/src/pages/details/awsDetails/detailsSummary.tsx
@@ -27,7 +27,7 @@ export const enum AwsDetailsTab {
 
 const DetailsSummary: React.SFC<Omit<
   SummaryProps,
-  'availableTabs' | 'getIdKeyForTab' | 't'
+  'availableTabs' | 'getIdKeyForTab' | 'intl'
 >> = props => (
   <Summary
     availableTabs={[

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -19,7 +19,7 @@ import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterS
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { Actions } from 'pages/details/components/actions/actions';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
 import {
@@ -51,7 +51,7 @@ interface DetailsTableState {
   rows?: any[];
 }
 
-type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
+type DetailsTableProps = DetailsTableOwnProps & WrappedComponentProps;
 
 const reportPathsType = ReportPathsType.aws;
 
@@ -90,7 +90,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   private initDatum = () => {
-    const { query, report, t } = this.props;
+    const { query, report, intl } = this.props;
     if (!query || !report) {
       return;
     }
@@ -111,14 +111,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const columns = groupByTagKey
       ? [
           {
-            title: t('ocp_details.tag_column_title'),
+            title: intl.formatMessage({ id: 'ocp_details.tag_column_title' }),
           },
           {
-            title: t('aws_details.change_column_title'),
+            title: intl.formatMessage({
+              id: 'aws_details.change_column_title',
+            }),
           },
           {
             orderBy: 'cost',
-            title: t('aws_details.cost_column_title', { total }),
+            title: intl.formatMessage(
+              { id: 'aws_details.cost_column_title' },
+              { total }
+            ),
             transforms: [sortable],
           },
           {
@@ -128,15 +133,20 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       : [
           {
             orderBy: groupById === 'account' ? 'account_alias' : groupById,
-            title: t('aws_details.name_column_title', { groupBy: groupById }),
+            title: intl.formatMessage(
+              { id: 'aws_details.name_column_title' },
+              { groupBy: groupById }
+            ),
             transforms: [sortable],
           },
           {
-            title: t('aws_details.change_column_title'),
+            title: intl.formatMessage({
+              id: 'aws_details.change_column_title',
+            }),
           },
           {
             orderBy: 'cost',
-            title: t('aws_details.cost_column_title'),
+            title: intl.formatMessage({ id: 'aws_details.cost_column_title' }),
             transforms: [sortable],
           },
           {
@@ -179,7 +189,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           parent: index * 2,
           cells: [
             {
-              title: <div key={`${index * 2}-child`}>{t('loading')}</div>,
+              title: (
+                <div key={`${index * 2}-child`}>
+                  {intl.formatMessage({ id: 'loading' })}
+                </div>
+              ),
             },
           ],
         }
@@ -211,7 +225,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getEmptyState = () => {
-    const { query, t } = this.props;
+    const { query, intl } = this.props;
 
     for (const val of Object.values(query.group_by)) {
       if (val !== '*') {
@@ -221,7 +235,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{t('ocp_cloud_details.empty_state')}</EmptyStateBody>
+        <EmptyStateBody>
+          {intl.formatMessage({ id: 'ocp_cloud_details.empty_state' })}
+        </EmptyStateBody>
       </EmptyState>
     );
   };
@@ -243,7 +259,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
@@ -269,7 +285,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <div className={monthOverMonthOverride}>
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
             {Boolean(showPercentage) ? (
-              t('percent', { value: percentage })
+              intl.formatMessage({ id: 'percent' }, { value: percentage })
             ) : (
               <EmptyValueState />
             )}
@@ -351,7 +367,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getTotalCost = (item: ComputedReportItem, index: number) => {
-    const { report, t } = this.props;
+    const { report, intl } = this.props;
     const cost =
       report &&
       report.meta &&
@@ -365,16 +381,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.cost)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {t('percent_of_cost', {
-            value: ((item.cost / cost) * 100).toFixed(2),
-          })}
+          {intl.formatMessage(
+            { id: 'percent_of_cost' },
+            {
+              value: ((item.cost / cost) * 100).toFixed(2),
+            }
+          )}
         </div>
       </>
     );
   };
 
   private handleOnCollapse = (event, rowId, isOpen) => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const { rows } = this.state;
     const {
       tableItem: { item, groupBy, query, index },
@@ -386,7 +405,13 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ];
     } else {
       rows[rowId + 1].cells = [
-        { title: <div key={`${index * 2}-child`}>{t('loading')}</div> },
+        {
+          title: (
+            <div key={`${index * 2}-child`}>
+              {intl.formatMessage({ id: 'loading' })}
+            </div>
+          ),
+        },
       ];
     }
     rows[rowId].isOpen = isOpen;
@@ -460,6 +485,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 }
 
-const DetailsTable = translate()(connect()(DetailsTableBase));
+const DetailsTable = injectIntl(connect()(DetailsTableBase));
 
 export { DetailsTable, DetailsTableProps };

--- a/src/pages/details/awsDetails/detailsTableItem.tsx
+++ b/src/pages/details/awsDetails/detailsTableItem.tsx
@@ -11,7 +11,7 @@ import { ReportPathsType } from 'api/reports/report';
 import { HistoricalModal } from 'pages/details/components/historicalChart/historicalModal';
 import { Tag } from 'pages/details/components/tag/tag';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { getTestProps, testIds } from 'testIds';
@@ -28,7 +28,7 @@ interface DetailsTableItemState {
   isHistoricalModalOpen: boolean;
 }
 
-type DetailsTableItemProps = DetailsTableItemOwnProps & InjectedTranslateProps;
+type DetailsTableItemProps = DetailsTableItemOwnProps & WrappedComponentProps;
 
 const reportPathsType = ReportPathsType.aws;
 
@@ -54,7 +54,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
   };
 
   public render() {
-    const { item, groupBy, t } = this.props;
+    const { item, groupBy, intl } = this.props;
     const { isHistoricalModalOpen } = this.state;
 
     return (
@@ -68,7 +68,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 type={ButtonType.button}
                 variant={ButtonVariant.secondary}
               >
-                {t('details.historical.view_data')}
+                {intl.formatMessage({ id: 'details.historical.view_data' })}
               </Button>
             </div>
           </GridItem>
@@ -87,7 +87,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 <div style={styles.tagsContainer}>
                   <Form>
                     <FormGroup
-                      label={t('aws_details.tags_label')}
+                      label={intl.formatMessage({
+                        id: 'aws_details.tags_label',
+                      })}
                       fieldId="tags"
                     >
                       <Tag
@@ -122,7 +124,7 @@ const mapStateToProps = createMapStateToProps<DetailsTableItemOwnProps, {}>(
   }
 );
 
-const DetailsTableItem = translate()(
+const DetailsTableItem = injectIntl(
   connect(mapStateToProps, {})(DetailsTableItemBase)
 );
 

--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -4,7 +4,7 @@ import { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -38,7 +38,7 @@ interface DetailsToolbarState {
 type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarStateProps &
   DetailsToolbarDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.aws;
@@ -68,13 +68,22 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report, t } = this.props;
+    const { report, intl } = this.props;
 
     const options = [
-      { name: t('filter_by.values.account'), key: 'account' },
-      { name: t('filter_by.values.service'), key: 'service' },
-      { name: t('filter_by.values.region'), key: 'region' },
-      { name: t('filter_by.values.tag'), key: 'tag' },
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.account' }),
+        key: 'account',
+      },
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.service' }),
+        key: 'service',
+      },
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.region' }),
+        key: 'region',
+      },
+      { name: intl.formatMessage({ id: 'filter_by.values.tag' }), key: 'tag' },
     ];
 
     return report && report.data && report.data.length
@@ -147,7 +156,7 @@ const mapDispatchToProps: DetailsToolbarDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const DetailsToolbar = translate()(
+const DetailsToolbar = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(DetailsToolbarBase)
 );
 

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -16,7 +16,7 @@ import { LoadingState } from 'components/state/loadingState/loadingState';
 import { NoProvidersState } from 'components/state/noProvidersState/noProvidersState';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -54,7 +54,7 @@ interface AzureDetailsState {
   selectedItems: ComputedReportItem[];
 }
 
-type AzureDetailsOwnProps = RouteComponentProps<void> & InjectedTranslateProps;
+type AzureDetailsOwnProps = RouteComponentProps<void> & WrappedComponentProps;
 
 type AzureDetailsProps = AzureDetailsStateProps &
   AzureDetailsOwnProps &
@@ -515,6 +515,6 @@ const mapDispatchToProps: AzureDetailsDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-export default translate()(
+export default injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(AzureDetails)
 );

--- a/src/pages/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/details/azureDetails/detailsHeader.tsx
@@ -11,7 +11,7 @@ import {
   TertiaryNavItem,
 } from 'pages/details/components/nav/tertiaryNav';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { azureProvidersQuery, providersSelectors } from 'store/providers';
@@ -38,7 +38,7 @@ interface DetailsHeaderStateProps {
 
 type DetailsHeaderProps = DetailsHeaderOwnProps &
   DetailsHeaderStateProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const baseQuery: AzureQuery = {
   delta: 'cost',
@@ -68,7 +68,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers,
       providersError,
       report,
-      t,
+      intl,
     } = this.props;
     const showContent =
       report &&
@@ -88,7 +88,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       <header style={styles.header}>
         <div>
           <Title style={styles.title} size={TitleSize['2xl']}>
-            {t('navigation.infrastructure_details')}
+            {intl.formatMessage({ id: 'navigation.infrastructure_details' })}
           </Title>
           <div style={styles.nav}>
             <TertiaryNav activeItem={TertiaryNavItem.azure} />
@@ -109,7 +109,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             </Title>
             <div style={styles.costLabel}>
               <div style={styles.costLabelUnit}>
-                {t('azure_details.total_cost')}
+                {intl.formatMessage({ id: 'azure_details.total_cost' })}
               </div>
               <div style={styles.costLabelDate}>
                 {getSinceDateRangeString()}
@@ -152,7 +152,7 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const DetailsHeader = translate()(
+const DetailsHeader = injectIntl(
   connect(mapStateToProps, {})(DetailsHeaderBase)
 );
 

--- a/src/pages/details/azureDetails/detailsSummary.tsx
+++ b/src/pages/details/azureDetails/detailsSummary.tsx
@@ -27,7 +27,7 @@ export const enum AzureDetailsTab {
 
 const DetailsSummary: React.SFC<Omit<
   SummaryProps,
-  'availableTabs' | 'getIdKeyForTab' | 't'
+  'availableTabs' | 'getIdKeyForTab' | 'intl'
 >> = props => (
   <Summary
     availableTabs={[

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -19,7 +19,7 @@ import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterS
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { Actions } from 'pages/details/components/actions/actions';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAzureReportItems';
 import {
@@ -51,7 +51,7 @@ interface DetailsTableState {
   rows?: any[];
 }
 
-type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
+type DetailsTableProps = DetailsTableOwnProps & WrappedComponentProps;
 
 const reportPathsType = ReportPathsType.azure;
 
@@ -90,7 +90,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   private initDatum = () => {
-    const { query, report, t } = this.props;
+    const { query, report, intl } = this.props;
     if (!query || !report) {
       return;
     }
@@ -111,14 +111,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const columns = groupByTagKey
       ? [
           {
-            title: t('ocp_details.tag_column_title'),
+            title: intl.formatMessage({ id: 'ocp_details.tag_column_title' }),
           },
           {
-            title: t('azure_details.change_column_title'),
+            title: intl.formatMessage({
+              id: 'azure_details.change_column_title',
+            }),
           },
           {
             orderBy: 'cost',
-            title: t('azure_details.cost_column_title', { total }),
+            title: intl.formatMessage(
+              { id: 'azure_details.cost_column_title' },
+              { total }
+            ),
             transforms: [sortable],
           },
           {
@@ -128,15 +133,22 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       : [
           {
             orderBy: groupById,
-            title: t('azure_details.name_column_title', { groupBy: groupById }),
+            title: intl.formatMessage(
+              { id: 'azure_details.name_column_title' },
+              { groupBy: groupById }
+            ),
             transforms: [sortable],
           },
           {
-            title: t('azure_details.change_column_title'),
+            title: intl.formatMessage({
+              id: 'azure_details.change_column_title',
+            }),
           },
           {
             orderBy: 'cost',
-            title: t('azure_details.cost_column_title'),
+            title: intl.formatMessage({
+              id: 'azure_details.cost_column_title',
+            }),
             transforms: [sortable],
           },
           {
@@ -179,7 +191,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           parent: index * 2,
           cells: [
             {
-              title: <div key={`${index * 2}-child`}>{t('loading')}</div>,
+              title: (
+                <div key={`${index * 2}-child`}>
+                  {intl.formatMessage({ id: 'loading' })}
+                </div>
+              ),
             },
           ],
         }
@@ -211,7 +227,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getEmptyState = () => {
-    const { query, t } = this.props;
+    const { query, intl } = this.props;
 
     for (const val of Object.values(query.group_by)) {
       if (val !== '*') {
@@ -221,7 +237,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{t('ocp_cloud_details.empty_state')}</EmptyStateBody>
+        <EmptyStateBody>
+          {intl.formatMessage({ id: 'ocp_cloud_details.empty_state' })}
+        </EmptyStateBody>
       </EmptyState>
     );
   };
@@ -243,7 +261,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
@@ -269,7 +287,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <div className={monthOverMonthOverride}>
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
             {Boolean(showPercentage) ? (
-              t('percent', { value: percentage })
+              intl.formatMessage({ id: 'percent' }, { value: percentage })
             ) : (
               <EmptyValueState />
             )}
@@ -351,7 +369,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getTotalCost = (item: ComputedReportItem, index: number) => {
-    const { report, t } = this.props;
+    const { report, intl } = this.props;
     const cost =
       report &&
       report.meta &&
@@ -365,16 +383,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.cost)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {t('percent_of_cost', {
-            value: ((item.cost / cost) * 100).toFixed(2),
-          })}
+          {intl.formatMessage(
+            { id: 'percent_of_cost' },
+            {
+              value: ((item.cost / cost) * 100).toFixed(2),
+            }
+          )}
         </div>
       </>
     );
   };
 
   private handleOnCollapse = (event, rowId, isOpen) => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const { rows } = this.state;
     const {
       tableItem: { item, groupBy, query, index },
@@ -386,7 +407,13 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ];
     } else {
       rows[rowId + 1].cells = [
-        { title: <div key={`${index * 2}-child`}>{t('loading')}</div> },
+        {
+          title: (
+            <div key={`${index * 2}-child`}>
+              {intl.formatMessage({ id: 'loading' })}
+            </div>
+          ),
+        },
       ];
     }
     rows[rowId].isOpen = isOpen;
@@ -460,6 +487,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 }
 
-const DetailsTable = translate()(connect()(DetailsTableBase));
+const DetailsTable = injectIntl(connect()(DetailsTableBase));
 
 export { DetailsTable, DetailsTableProps };

--- a/src/pages/details/azureDetails/detailsTableItem.tsx
+++ b/src/pages/details/azureDetails/detailsTableItem.tsx
@@ -11,7 +11,7 @@ import { ReportPathsType } from 'api/reports/report';
 import { HistoricalModal } from 'pages/details/components/historicalChart/historicalModal';
 import { Tag } from 'pages/details/components/tag/tag';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { getTestProps, testIds } from 'testIds';
@@ -28,7 +28,7 @@ interface DetailsTableItemState {
   isHistoricalModalOpen: boolean;
 }
 
-type DetailsTableItemProps = DetailsTableItemOwnProps & InjectedTranslateProps;
+type DetailsTableItemProps = DetailsTableItemOwnProps & WrappedComponentProps;
 
 const reportPathsType = ReportPathsType.azure;
 
@@ -54,7 +54,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
   };
 
   public render() {
-    const { item, groupBy, t } = this.props;
+    const { item, groupBy, intl } = this.props;
     const { isHistoricalModalOpen } = this.state;
 
     return (
@@ -68,7 +68,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 type={ButtonType.button}
                 variant={ButtonVariant.secondary}
               >
-                {t('azure_details.historical.view_data')}
+                {intl.formatMessage({
+                  id: 'azure_details.historical.view_data',
+                })}
               </Button>
             </div>
           </GridItem>
@@ -87,7 +89,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 <div style={styles.tagsContainer}>
                   <Form>
                     <FormGroup
-                      label={t('azure_details.tags_label')}
+                      label={intl.formatMessage({
+                        id: 'azure_details.tags_label',
+                      })}
                       fieldId="tags"
                     >
                       <Tag
@@ -122,7 +126,7 @@ const mapStateToProps = createMapStateToProps<DetailsTableItemOwnProps, {}>(
   }
 );
 
-const DetailsTableItem = translate()(
+const DetailsTableItem = injectIntl(
   connect(mapStateToProps, {})(DetailsTableItemBase)
 );
 

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -4,7 +4,7 @@ import { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -38,7 +38,7 @@ interface DetailsToolbarState {
 type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarStateProps &
   DetailsToolbarDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.azure;
@@ -68,19 +68,22 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report, t } = this.props;
+    const { report, intl } = this.props;
 
     const options = [
       {
-        name: t('filter_by.values.subscription_guid'),
+        name: intl.formatMessage({ id: 'filter_by.values.subscription_guid' }),
         key: 'subscription_guid',
       },
-      { name: t('filter_by.values.service_name'), key: 'service_name' },
       {
-        name: t('filter_by.values.resource_location'),
+        name: intl.formatMessage({ id: 'filter_by.values.service_name' }),
+        key: 'service_name',
+      },
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.resource_location' }),
         key: 'resource_location',
       },
-      { name: t('filter_by.values.tag'), key: 'tag' },
+      { name: intl.formatMessage({ id: 'filter_by.values.tag' }), key: 'tag' },
     ];
 
     return report && report.data && report.data.length
@@ -153,7 +156,7 @@ const mapDispatchToProps: DetailsToolbarDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const DetailsToolbar = translate()(
+const DetailsToolbar = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(DetailsToolbarBase)
 );
 

--- a/src/pages/details/components/actions/actions.tsx
+++ b/src/pages/details/components/actions/actions.tsx
@@ -8,7 +8,7 @@ import { PriceListModal } from 'pages/details/components/priceList/priceListModa
 import { SummaryModal } from 'pages/details/components/summary/summaryModal';
 import { TagModal } from 'pages/details/components/tag/tagModal';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 
 interface DetailsActionsOwnProps {
@@ -32,7 +32,7 @@ interface DetailsActionsState {
   isSummaryModalOpen: boolean;
 }
 
-type DetailsActionsProps = DetailsActionsOwnProps & InjectedTranslateProps;
+type DetailsActionsProps = DetailsActionsOwnProps & WrappedComponentProps;
 
 class DetailsActionsBase extends React.Component<DetailsActionsProps> {
   protected defaultState: DetailsActionsState = {
@@ -203,7 +203,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
       isSummaryOptionDisabled,
       isTagOptionDisabled,
       showPriceListOption,
-      t,
+      intl,
     } = this.props;
 
     // tslint:disable:jsx-wrap-multiline
@@ -213,7 +213,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
         key="historical-data-action"
         onClick={this.handleHistoricalModalOpen}
       >
-        {t('details.actions.historical_data')}
+        {intl.formatMessage({ id: 'details.actions.historical_data' })}
       </DropdownItem>,
       <DropdownItem
         component="button"
@@ -221,7 +221,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
         isDisabled={isSummaryOptionDisabled}
         onClick={this.handleSummaryModalOpen}
       >
-        {t(`details.actions.${idKey}`)}
+        {intl.formatMessage({ id: `details.actions.${idKey}` })}
       </DropdownItem>,
       <DropdownItem
         component="button"
@@ -229,14 +229,14 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
         isDisabled={isTagOptionDisabled}
         onClick={this.handleTagModalOpen}
       >
-        {t('details.actions.tags')}
+        {intl.formatMessage({ id: 'details.actions.tags' })}
       </DropdownItem>,
       <DropdownItem
         component="button"
         key="export-action"
         onClick={this.handleExportModalOpen}
       >
-        {t('details.actions.export')}
+        {intl.formatMessage({ id: 'details.actions.export' })}
       </DropdownItem>,
     ];
     // tslint:enable:jsx-wrap-multiline
@@ -249,7 +249,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
           isDisabled={groupBy.includes(tagKeyPrefix)}
           onClick={this.handlePriceListModalOpen}
         >
-          {t('details.actions.price_list')}
+          {intl.formatMessage({ id: 'details.actions.price_list' })}
         </DropdownItem>
       );
     }
@@ -274,6 +274,6 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
   }
 }
 
-const Actions = translate()(DetailsActionsBase);
+const Actions = injectIntl(DetailsActionsBase);
 
 export { Actions };

--- a/src/pages/details/components/bulletChart/bulletChart.tsx
+++ b/src/pages/details/components/bulletChart/bulletChart.tsx
@@ -14,7 +14,7 @@ import { getQuery, Query } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -55,7 +55,7 @@ interface State {
 type BulletChartProps = BulletChartOwnProps &
   BulletChartStateProps &
   BulletChartDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const cpuReportType = ReportType.cpu;
 const memoryReportType = ReportType.memory;
@@ -94,7 +94,7 @@ class BulletChartBase extends React.Component<BulletChartProps> {
   };
 
   private getChartDatum(report: Report, labelKey: string): ChartDatum {
-    const { t } = this.props;
+    const { intl } = this.props;
     const datum: ChartDatum = {
       legend: [],
       limit: {},
@@ -108,18 +108,26 @@ class BulletChartBase extends React.Component<BulletChartProps> {
     const hasLimit =
       hasTotal && report.meta.total.limit && report.meta.total.limit !== null;
     const limit = Math.trunc(hasLimit ? report.meta.total.limit.value : 0);
-    const limitUnits = t(
-      `units.${unitLookupKey(hasLimit ? report.meta.total.limit.units : '')}`
-    );
+    const limitUnits = intl.formatMessage({
+      id: `units.${unitLookupKey(
+        hasLimit ? report.meta.total.limit.units : ''
+      )}`,
+    });
     datum.limit = {
-      legend: t(`details.bullet.${labelKey}_limit`, {
-        value: limit,
-        units: limitUnits,
-      }),
-      tooltip: t(`details.bullet.${labelKey}_limit`, {
-        value: limit,
-        units: limitUnits,
-      }),
+      legend: intl.formatMessage(
+        { id: `details.bullet.${labelKey}_limit` },
+        {
+          value: limit,
+          units: limitUnits,
+        }
+      ),
+      tooltip: intl.formatMessage(
+        { id: `details.bullet.${labelKey}_limit` },
+        {
+          value: limit,
+          units: limitUnits,
+        }
+      ),
       value: Math.trunc(limit),
     };
 
@@ -130,21 +138,27 @@ class BulletChartBase extends React.Component<BulletChartProps> {
     const request = Math.trunc(
       hasRequest ? report.meta.total.request.value : 0
     );
-    const requestUnits = t(
-      `units.${unitLookupKey(
+    const requestUnits = intl.formatMessage({
+      id: `units.${unitLookupKey(
         hasRequest ? report.meta.total.request.units : ''
-      )}`
-    );
+      )}`,
+    });
     datum.ranges = [
       {
-        legend: t(`details.bullet.${labelKey}_requests`, {
-          value: request,
-          units: requestUnits,
-        }),
-        tooltip: t(`details.bullet.${labelKey}_requests`, {
-          value: request,
-          units: requestUnits,
-        }),
+        legend: intl.formatMessage(
+          { id: `details.bullet.${labelKey}_requests` },
+          {
+            value: request,
+            units: requestUnits,
+          }
+        ),
+        tooltip: intl.formatMessage(
+          { id: `details.bullet.${labelKey}_requests` },
+          {
+            value: request,
+            units: requestUnits,
+          }
+        ),
         value: Math.trunc(request),
       },
     ];
@@ -152,19 +166,27 @@ class BulletChartBase extends React.Component<BulletChartProps> {
     const hasUsage =
       hasTotal && report.meta.total.usage && report.meta.total.usage !== null;
     const usage = Math.trunc(hasUsage ? report.meta.total.usage.value : 0);
-    const usageUnits = t(
-      `units.${unitLookupKey(hasUsage ? report.meta.total.usage.units : '')}`
-    );
+    const usageUnits = intl.formatMessage({
+      id: `units.${unitLookupKey(
+        hasUsage ? report.meta.total.usage.units : ''
+      )}`,
+    });
     datum.usage = [
       {
-        legend: t(`details.bullet.${labelKey}_usage`, {
-          value: usage,
-          units: usageUnits,
-        }),
-        tooltip: t(`details.bullet.${labelKey}_usage`, {
-          value: usage,
-          units: usageUnits,
-        }),
+        legend: intl.formatMessage(
+          { id: `details.bullet.${labelKey}_usage` },
+          {
+            value: usage,
+            units: usageUnits,
+          }
+        ),
+        tooltip: intl.formatMessage(
+          { id: `details.bullet.${labelKey}_usage` },
+          {
+            value: usage,
+            units: usageUnits,
+          }
+        ),
         value: Math.trunc(usage),
       },
     ];
@@ -175,7 +197,7 @@ class BulletChartBase extends React.Component<BulletChartProps> {
     report: Report,
     labelKey: string
   ): ChartDatum {
-    const { t } = this.props;
+    const { intl } = this.props;
     const datum: ChartDatum = {
       legend: [],
       limit: {},
@@ -189,18 +211,26 @@ class BulletChartBase extends React.Component<BulletChartProps> {
     const hasLimit =
       hasTotal && report.meta.total.limit && report.meta.total.limit !== null;
     const limit = Math.trunc(hasLimit ? report.meta.total.limit.value : 0);
-    const limitUnits = t(
-      `units.${unitLookupKey(hasLimit ? report.meta.total.limit.units : '')}`
-    );
+    const limitUnits = intl.formatMessage({
+      id: `units.${unitLookupKey(
+        hasLimit ? report.meta.total.limit.units : ''
+      )}`,
+    });
     datum.limit = {
-      legend: t(`details.bullet.${labelKey}_limit`, {
-        value: limit,
-        units: limitUnits,
-      }),
-      tooltip: t(`details.bullet.${labelKey}_limit`, {
-        value: limit,
-        units: limitUnits,
-      }),
+      legend: intl.formatMessage(
+        { id: `details.bullet.${labelKey}_limit` },
+        {
+          value: limit,
+          units: limitUnits,
+        }
+      ),
+      tooltip: intl.formatMessage(
+        { id: `details.bullet.${labelKey}_limit` },
+        {
+          value: limit,
+          units: limitUnits,
+        }
+      ),
       value: Math.trunc(limit),
     };
 
@@ -211,21 +241,27 @@ class BulletChartBase extends React.Component<BulletChartProps> {
     const capacity = Math.trunc(
       hasCapacity ? report.meta.total.capacity.value : 0
     );
-    const capacityUnits = t(
-      `units.${unitLookupKey(
+    const capacityUnits = intl.formatMessage({
+      id: `units.${unitLookupKey(
         hasCapacity ? report.meta.total.capacity.units : ''
-      )}`
-    );
+      )}`,
+    });
     datum.ranges = [
       {
-        legend: t(`details.bullet.${labelKey}_capacity`, {
-          value: capacity,
-          units: capacityUnits,
-        }),
-        tooltip: t(`details.bullet.${labelKey}_capacity`, {
-          value: capacity,
-          units: capacityUnits,
-        }),
+        legend: intl.formatMessage(
+          { id: `details.bullet.${labelKey}_capacity` },
+          {
+            value: capacity,
+            units: capacityUnits,
+          }
+        ),
+        tooltip: intl.formatMessage(
+          { id: `details.bullet.${labelKey}_capacity` },
+          {
+            value: capacity,
+            units: capacityUnits,
+          }
+        ),
         value: Math.trunc(capacity),
       },
     ];
@@ -239,36 +275,50 @@ class BulletChartBase extends React.Component<BulletChartProps> {
     const request = Math.trunc(
       hasRequest ? report.meta.total.request.value : 0
     );
-    const requestUnits = t(
-      `units.${unitLookupKey(
+    const requestUnits = intl.formatMessage({
+      id: `units.${unitLookupKey(
         hasRequest ? report.meta.total.request.units : ''
-      )}`
-    );
+      )}`,
+    });
     const usage = Math.trunc(hasUsage ? report.meta.total.usage.value : 0);
-    const usageUnits = t(
-      `units.${unitLookupKey(hasUsage ? report.meta.total.usage.units : '')}`
-    );
+    const usageUnits = intl.formatMessage({
+      id: `units.${unitLookupKey(
+        hasUsage ? report.meta.total.usage.units : ''
+      )}`,
+    });
     datum.usage = [
       {
-        legend: t(`details.bullet.${labelKey}_usage`, {
-          value: usage,
-          units: usageUnits,
-        }),
-        tooltip: t(`details.bullet.${labelKey}_usage`, {
-          value: usage,
-          units: usageUnits,
-        }),
+        legend: intl.formatMessage(
+          { id: `details.bullet.${labelKey}_usage` },
+          {
+            value: usage,
+            units: usageUnits,
+          }
+        ),
+        tooltip: intl.formatMessage(
+          { id: `details.bullet.${labelKey}_usage` },
+          {
+            value: usage,
+            units: usageUnits,
+          }
+        ),
         value: Math.trunc(usage),
       },
       {
-        legend: t(`details.bullet.${labelKey}_requests`, {
-          value: request,
-          units: requestUnits,
-        }),
-        tooltip: t(`details.bullet.${labelKey}_requests`, {
-          value: request,
-          units: requestUnits,
-        }),
+        legend: intl.formatMessage(
+          { id: `details.bullet.${labelKey}_requests` },
+          {
+            value: request,
+            units: requestUnits,
+          }
+        ),
+        tooltip: intl.formatMessage(
+          { id: `details.bullet.${labelKey}_requests` },
+          {
+            value: request,
+            units: requestUnits,
+          }
+        ),
         value: Math.trunc(request),
       },
     ];
@@ -276,7 +326,7 @@ class BulletChartBase extends React.Component<BulletChartProps> {
   }
 
   private getCpuChart = () => {
-    const { cpuReportFetchStatus, cpuReport, groupBy, t } = this.props;
+    const { cpuReportFetchStatus, cpuReport, groupBy, intl } = this.props;
     const { width } = this.state;
 
     const cpuDatum =
@@ -354,7 +404,7 @@ class BulletChartBase extends React.Component<BulletChartProps> {
                   ? [{ name: cpuDatum.ranges[0].legend }]
                   : []
               }
-              title={t('details.bullet.cpu_label')}
+              title={intl.formatMessage({ id: 'details.bullet.cpu_label' })}
               titlePosition="top-left"
               width={width}
             />
@@ -367,7 +417,7 @@ class BulletChartBase extends React.Component<BulletChartProps> {
   };
 
   private getFreeSpace(report: Report, labelKey: string) {
-    const { t } = this.props;
+    const { intl } = this.props;
     const hasTotal = report && report.meta && report.meta.total;
     const hasCapacity =
       hasTotal &&
@@ -386,15 +436,17 @@ class BulletChartBase extends React.Component<BulletChartProps> {
     const request = Math.trunc(
       hasRequest ? report.meta.total.request.value : 0
     );
-    const requestUnits = t(
-      `units.${unitLookupKey(
+    const requestUnits = intl.formatMessage({
+      id: `units.${unitLookupKey(
         hasRequest ? report.meta.total.request.units : ''
-      )}`
-    );
+      )}`,
+    });
     const usage = Math.trunc(hasUsage ? report.meta.total.usage.value : 0);
-    const usageUnits = t(
-      `units.${unitLookupKey(hasUsage ? report.meta.total.usage.units : '')}`
-    );
+    const usageUnits = intl.formatMessage({
+      id: `units.${unitLookupKey(
+        hasUsage ? report.meta.total.usage.units : ''
+      )}`,
+    });
 
     // Show negative values https://github.com/project-koku/koku-ui/issues/1214
     const unusedRequestCapacity = capacity - request;
@@ -415,30 +467,40 @@ class BulletChartBase extends React.Component<BulletChartProps> {
       <TextContent style={styles.freeSpace}>
         <TextList component={TextListVariants.dl}>
           <TextListItem component={TextListItemVariants.dt}>
-            {t(`details.bullet.${labelKey}_usage_unused_label`)}
+            {intl.formatMessage({
+              id: `details.bullet.${labelKey}_usage_unused_label`,
+            })}
           </TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
-            {t(`details.bullet.${labelKey}_usage_unused`, {
-              percentage: formatValue(
-                unusedUsageCapacityPercentage,
-                usageUnits
-              ),
-              value: unusedUsageCapacity,
-              units: usageUnits,
-            })}
+            {intl.formatMessage(
+              { id: `details.bullet.${labelKey}_usage_unused` },
+              {
+                percentage: formatValue(
+                  unusedUsageCapacityPercentage,
+                  usageUnits
+                ),
+                value: unusedUsageCapacity,
+                units: usageUnits,
+              }
+            )}
           </TextListItem>
           <TextListItem component={TextListItemVariants.dt}>
-            {t(`details.bullet.${labelKey}_requests_unused_label`)}
+            {intl.formatMessage({
+              id: `details.bullet.${labelKey}_requests_unused_label`,
+            })}
           </TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
-            {t(`details.bullet.${labelKey}_requests_unused`, {
-              percentage: formatValue(
-                unusedRequestCapacityPercentage,
-                requestUnits
-              ),
-              value: unusedRequestCapacity,
-              units: requestUnits,
-            })}
+            {intl.formatMessage(
+              { id: `details.bullet.${labelKey}_requests_unused` },
+              {
+                percentage: formatValue(
+                  unusedRequestCapacityPercentage,
+                  requestUnits
+                ),
+                value: unusedRequestCapacity,
+                units: requestUnits,
+              }
+            )}
           </TextListItem>
         </TextList>
       </TextContent>
@@ -451,7 +513,7 @@ class BulletChartBase extends React.Component<BulletChartProps> {
   };
 
   private getMemoryChart = () => {
-    const { memoryReportFetchStatus, memoryReport, groupBy, t } = this.props;
+    const { memoryReportFetchStatus, memoryReport, groupBy, intl } = this.props;
     const { width } = this.state;
 
     const memoryDatum =
@@ -531,7 +593,7 @@ class BulletChartBase extends React.Component<BulletChartProps> {
                   ? [{ name: memoryDatum.ranges[0].legend }]
                   : []
               }
-              title={t('details.bullet.memory_label')}
+              title={intl.formatMessage({ id: 'details.bullet.memory_label' })}
               titlePosition="top-left"
               width={width}
             />
@@ -633,7 +695,7 @@ const mapDispatchToProps: BulletChartDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const BulletChart = translate()(
+const BulletChart = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(BulletChartBase)
 );
 

--- a/src/pages/details/components/cluster/cluster.tsx
+++ b/src/pages/details/components/cluster/cluster.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { getTestProps, testIds } from 'testIds';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
@@ -16,7 +16,7 @@ interface ClusterState {
   showAll: boolean;
 }
 
-type ClusterProps = ClusterOwnProps & InjectedTranslateProps;
+type ClusterProps = ClusterOwnProps & WrappedComponentProps;
 
 class ClusterBase extends React.Component<ClusterProps> {
   protected defaultState: ClusterState = {
@@ -42,7 +42,7 @@ class ClusterBase extends React.Component<ClusterProps> {
   };
 
   public render() {
-    const { groupBy, item, t } = this.props;
+    const { groupBy, item, intl } = this.props;
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
@@ -85,9 +85,12 @@ class ClusterBase extends React.Component<ClusterProps> {
             href="#/"
             onClick={this.handleOpen}
           >
-            {t('details.more_clusters', {
-              value: allClusters.length - someClusters.length,
-            })}
+            {intl.formatMessage(
+              { id: 'details.more_clusters' },
+              {
+                value: allClusters.length - someClusters.length,
+              }
+            )}
           </a>
         )}
         <ClusterModal
@@ -101,6 +104,6 @@ class ClusterBase extends React.Component<ClusterProps> {
   }
 }
 
-const Cluster = translate()(connect()(ClusterBase));
+const Cluster = injectIntl(connect()(ClusterBase));
 
 export { Cluster, ClusterProps };

--- a/src/pages/details/components/cluster/clusterModal.tsx
+++ b/src/pages/details/components/cluster/clusterModal.tsx
@@ -1,6 +1,6 @@
 import { Modal } from '@patternfly/react-core';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { modalOverride, styles } from './clusterModal.styles';
 import { ClusterView } from './clusterView';
@@ -12,7 +12,7 @@ interface ClusterModalOwnProps {
   onClose(isOpen: boolean);
 }
 
-type ClusterModalProps = ClusterModalOwnProps & InjectedTranslateProps;
+type ClusterModalProps = ClusterModalOwnProps & WrappedComponentProps;
 
 class ClusterModalBase extends React.Component<ClusterModalProps> {
   constructor(props: ClusterModalProps) {
@@ -30,7 +30,7 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
   };
 
   public render() {
-    const { groupBy, isOpen, item, t } = this.props;
+    const { groupBy, isOpen, item, intl } = this.props;
 
     return (
       <Modal
@@ -38,10 +38,13 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
         style={styles.modal}
         isOpen={isOpen}
         onClose={this.handleClose}
-        title={t('details.clusters_modal_title', {
-          groupBy,
-          name: item.label,
-        })}
+        title={intl.formatMessage(
+          { id: 'details.clusters_modal_title' },
+          {
+            groupBy,
+            name: item.label,
+          }
+        )}
         width={'50%'}
       >
         <ClusterView item={item} />
@@ -50,6 +53,6 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
   }
 }
 
-const ClusterModal = translate()(ClusterModalBase);
+const ClusterModal = injectIntl(ClusterModalBase);
 
 export { ClusterModal };

--- a/src/pages/details/components/cluster/clusterView.tsx
+++ b/src/pages/details/components/cluster/clusterView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 
@@ -7,7 +7,7 @@ interface ClusterViewOwnProps {
   item: ComputedReportItem;
 }
 
-type ClusterViewProps = ClusterViewOwnProps & InjectedTranslateProps;
+type ClusterViewProps = ClusterViewOwnProps & WrappedComponentProps;
 
 class ClusterViewBase extends React.Component<ClusterViewProps> {
   public render() {
@@ -22,6 +22,6 @@ class ClusterViewBase extends React.Component<ClusterViewProps> {
   }
 }
 
-const ClusterView = translate()(connect()(ClusterViewBase));
+const ClusterView = injectIntl(connect()(ClusterViewBase));
 
 export { ClusterView, ClusterViewBase };

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -11,7 +11,7 @@ import { Query, tagKeyPrefix } from 'api/queries/query';
 import { ReportPathsType } from 'api/reports/report';
 import { AxiosError } from 'axios';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { exportActions } from 'store/exports';
@@ -21,7 +21,7 @@ import { sort, SortDirection } from 'utils/sort';
 import { styles } from './exportModal.styles';
 import { ExportSubmit } from './exportSubmit';
 
-export interface ExportModalOwnProps extends InjectedTranslateProps {
+export interface ExportModalOwnProps extends WrappedComponentProps {
   error?: AxiosError;
   export?: string;
   groupBy?: string;
@@ -44,7 +44,7 @@ interface ExportModalState {
 
 type ExportModalProps = ExportModalOwnProps &
   ExportModalDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const resolutionOptions: {
   label: string;
@@ -91,7 +91,7 @@ export class ExportModalBase extends React.Component<
       items,
       query,
       reportPathsType,
-      t,
+      intl,
     } = this.props;
     const { resolution } = this.state;
 
@@ -103,9 +103,12 @@ export class ExportModalBase extends React.Component<
       });
     }
 
-    let selectedLabel = t('export.selected', { groupBy });
+    let selectedLabel = intl.formatMessage(
+      { id: 'export.selected' },
+      { groupBy }
+    );
     if (groupBy.indexOf(tagKeyPrefix) !== -1) {
-      selectedLabel = t('export.selected_tags');
+      selectedLabel = intl.formatMessage({ id: 'export.selected_tags' });
     }
 
     return (
@@ -114,7 +117,7 @@ export class ExportModalBase extends React.Component<
         isLarge
         isOpen={this.props.isOpen}
         onClose={this.handleClose}
-        title={t('export.title')}
+        title={intl.formatMessage({ id: 'export.title' })}
         actions={[
           <Button
             {...getTestProps(testIds.export.cancel_btn)}
@@ -122,7 +125,7 @@ export class ExportModalBase extends React.Component<
             onClick={this.handleClose}
             variant={ButtonVariant.secondary}
           >
-            {t('export.cancel')}
+            {intl.formatMessage({ id: 'export.cancel' })}
           </Button>,
           <ExportSubmit
             groupBy={groupBy}
@@ -137,11 +140,11 @@ export class ExportModalBase extends React.Component<
         ]}
       >
         <Title style={styles.title} size="xl">
-          {t('export.heading', { groupBy })}
+          {intl.formatMessage({ id: 'export.heading' }, { groupBy })}
         </Title>
         <Form style={styles.form}>
           <FormGroup
-            label={t('export.aggregate_type')}
+            label={intl.formatMessage({ id: 'export.aggregate_type' })}
             fieldId="aggregate-type"
           >
             <React.Fragment>
@@ -150,12 +153,12 @@ export class ExportModalBase extends React.Component<
                   key={index}
                   id={`resolution-${index}`}
                   isValid={option.value !== undefined}
-                  label={t(option.label)}
+                  label={intl.formatMessage({ id: option.label })}
                   value={option.value}
                   checked={resolution === option.value}
                   name="resolution"
                   onChange={this.handleResolutionChange}
-                  aria-label={t(option.label)}
+                  aria-label={intl.formatMessage({ id: option.label })}
                 />
               ))}
             </React.Fragment>
@@ -183,7 +186,7 @@ const mapDispatchToProps: ExportModalDispatchProps = {
   exportReport: exportActions.exportReport,
 };
 
-const ExportModal = translate()(
+const ExportModal = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(ExportModalBase)
 );
 

--- a/src/pages/details/components/export/exportSubmit.tsx
+++ b/src/pages/details/components/export/exportSubmit.tsx
@@ -6,14 +6,14 @@ import { AxiosError } from 'axios';
 import formatDate from 'date-fns/format';
 import fileDownload from 'js-file-download';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { exportActions, exportSelectors } from 'store/exports';
 import { getTestProps, testIds } from 'testIds';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 
-export interface ExportSubmitOwnProps extends InjectedTranslateProps {
+export interface ExportSubmitOwnProps extends WrappedComponentProps {
   groupBy?: string;
   isAllItems?: boolean;
   items?: ComputedReportItem[];
@@ -41,7 +41,7 @@ interface ExportSubmitState {
 type ExportSubmitProps = ExportSubmitOwnProps &
   ExportSubmitStateProps &
   ExportSubmitDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const reportType = ReportType.cost;
 
@@ -75,13 +75,16 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
   };
 
   private getFileName = () => {
-    const { groupBy, reportPathsType, t } = this.props;
+    const { groupBy, reportPathsType, intl } = this.props;
 
-    const fileName = t('export.file_name', {
-      provider: reportPathsType,
-      groupBy,
-      date: formatDate(new Date(), 'YYYY-MM-DD'),
-    });
+    const fileName = intl.formatMessage(
+      { id: 'export.file_name' },
+      {
+        provider: reportPathsType,
+        groupBy,
+        date: formatDate(new Date(), 'YYYY-MM-DD'),
+      }
+    );
 
     return `${fileName}.csv`;
   };
@@ -110,7 +113,7 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
   };
 
   public render() {
-    const { reportFetchStatus, t } = this.props;
+    const { reportFetchStatus, intl } = this.props;
 
     return (
       <Button
@@ -120,7 +123,7 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
         onClick={this.handleFetchReport}
         variant={ButtonVariant.primary}
       >
-        {t('export.confirm')}
+        {intl.formatMessage({ id: 'export.confirm' })}
       </Button>
     );
   }
@@ -190,7 +193,7 @@ const mapDispatchToProps: ExportSubmitDispatchProps = {
   exportReport: exportActions.exportReport,
 };
 
-const ExportSubmit = translate()(
+const ExportSubmit = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(ExportSubmitBase)
 );
 

--- a/src/pages/details/components/groupBy/groupBy.tsx
+++ b/src/pages/details/components/groupBy/groupBy.tsx
@@ -4,10 +4,10 @@ import { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { uniq, uniqBy } from 'lodash';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
+import { intl } from '../../../../components/i18nProvider';
 import { styles } from './groupBy.styles';
 
 interface GroupByOwnProps {
@@ -38,10 +38,7 @@ interface GroupByState {
   isGroupByOpen: boolean;
 }
 
-type GroupByProps = GroupByOwnProps &
-  GroupByStateProps &
-  GroupByDispatchProps &
-  InjectedTranslateProps;
+type GroupByProps = GroupByOwnProps & GroupByStateProps & GroupByDispatchProps;
 
 const reportType = ReportType.tag;
 
@@ -89,7 +86,7 @@ class GroupByBase extends React.Component<GroupByProps> {
   };
 
   private getDropDownItems = () => {
-    const { options, t } = this.props;
+    const { options } = this.props;
 
     return options.map(option => (
       <DropdownItem
@@ -97,13 +94,13 @@ class GroupByBase extends React.Component<GroupByProps> {
         key={option.value}
         onClick={() => this.handleGroupByClick(option.value)}
       >
-        {t(`group_by.values.${option.label}`)}
+        {intl.formatMessage({ id: `group_by.values.${option.label}` })}
       </DropdownItem>
     ));
   };
 
   private getDropDownTags = () => {
-    const { report, t } = this.props;
+    const { report } = this.props;
 
     if (!(report && report.data)) {
       return [];
@@ -137,7 +134,7 @@ class GroupByBase extends React.Component<GroupByProps> {
           key={`${tagKeyPrefix}${tag.key}`}
           onClick={() => this.handleGroupByClick(`${tagKeyPrefix}${tagKey}`)}
         >
-          {t('group_by.tag_key', { value: tagKey })}
+          {intl.formatMessage({ id: 'group_by.tag_key' }, { value: tagKey })}
         </DropdownItem>
       );
     });
@@ -181,7 +178,7 @@ class GroupByBase extends React.Component<GroupByProps> {
   };
 
   public render() {
-    const { isDisabled = false, t } = this.props;
+    const { isDisabled = false } = this.props;
     const { currentItem, isGroupByOpen } = this.state;
 
     const dropdownItems = [
@@ -192,14 +189,19 @@ class GroupByBase extends React.Component<GroupByProps> {
     const index = currentItem ? currentItem.indexOf(tagKeyPrefix) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag_key', {
-            value: currentItem.slice(tagKeyPrefix.length),
-          })
-        : t(`group_by.values.${currentItem}`);
+        ? intl.formatMessage(
+            { id: 'group_by.tag_key' },
+            {
+              value: currentItem.slice(tagKeyPrefix.length),
+            }
+          )
+        : intl.formatMessage({ id: `group_by.values.${currentItem}` });
 
     return (
       <div style={styles.groupBySelector}>
-        <label style={styles.groupBySelectorLabel}>{t('group_by.cost')}:</label>
+        <label style={styles.groupBySelectorLabel}>
+          {intl.formatMessage({ id: 'group_by.cost' })}:
+        </label>
         <Dropdown
           onSelect={this.handleGroupBySelect}
           toggle={
@@ -253,8 +255,6 @@ const mapDispatchToProps: GroupByDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const GroupBy = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(GroupByBase)
-);
+const GroupBy = connect(mapStateToProps, mapDispatchToProps)(GroupByBase);
 
 export { GroupBy, GroupByProps };

--- a/src/pages/details/components/historicalChart/historicalChart.tsx
+++ b/src/pages/details/components/historicalChart/historicalChart.tsx
@@ -10,7 +10,7 @@ import {
 } from 'components/charts/common/chartUtils';
 import { HistoricalTrendChart } from 'components/charts/historicalTrendChart';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -45,7 +45,7 @@ interface HistoricalChartDispatchProps {
 type HistoricalChartProps = HistoricalChartOwnProps &
   HistoricalChartStateProps &
   HistoricalChartDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const costReportType = ReportType.cost;
 const instanceReportType = ReportType.instanceType;
@@ -114,7 +114,7 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
       previousInstanceReportFetchStatus,
       previousStorageReport,
       previousStorageReportFetchStatus,
-      t,
+      intl,
     } = this.props;
 
     // Cost data
@@ -181,11 +181,20 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
               formatDatumOptions={{}}
               height={chartStyles.chartHeight}
               previousData={previousCostData}
-              title={t('details.historical.cost_title')}
-              xAxisLabel={t('details.historical.day_of_month_label')}
-              yAxisLabel={t('details.historical.cost_label', {
-                units: t(`units.${unitLookupKey(costUnits)}`),
+              title={intl.formatMessage({
+                id: 'details.historical.cost_title',
               })}
+              xAxisLabel={intl.formatMessage({
+                id: 'details.historical.day_of_month_label',
+              })}
+              yAxisLabel={intl.formatMessage(
+                { id: 'details.historical.cost_label' },
+                {
+                  units: intl.formatMessage({
+                    id: `units.${unitLookupKey(costUnits)}`,
+                  }),
+                }
+              )}
             />
           )}
         </div>
@@ -201,10 +210,16 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
               formatDatumOptions={{}}
               height={chartStyles.chartHeight}
               previousData={previousInstanceData}
-              title={t('details.historical.instance_title')}
+              title={intl.formatMessage({
+                id: 'details.historical.instance_title',
+              })}
               showUsageLegendLabel
-              xAxisLabel={t('details.historical.day_of_month_label')}
-              yAxisLabel={t('details.historical.instance_label')}
+              xAxisLabel={intl.formatMessage({
+                id: 'details.historical.day_of_month_label',
+              })}
+              yAxisLabel={intl.formatMessage({
+                id: 'details.historical.instance_label',
+              })}
             />
           )}
         </div>
@@ -220,10 +235,16 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
               formatDatumOptions={{}}
               height={chartStyles.chartHeight}
               previousData={previousStorageData}
-              title={t('details.historical.storage_title')}
+              title={intl.formatMessage({
+                id: 'details.historical.storage_title',
+              })}
               showUsageLegendLabel
-              xAxisLabel={t('details.historical.day_of_month_label')}
-              yAxisLabel={t('details.historical.storage_label')}
+              xAxisLabel={intl.formatMessage({
+                id: 'details.historical.day_of_month_label',
+              })}
+              yAxisLabel={intl.formatMessage({
+                id: 'details.historical.storage_label',
+              })}
             />
           )}
         </div>
@@ -331,7 +352,7 @@ const mapDispatchToProps: HistoricalChartDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const HistoricalChart = translate()(
+const HistoricalChart = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(HistoricalChartBase)
 );
 

--- a/src/pages/details/components/historicalChart/historicalModal.tsx
+++ b/src/pages/details/components/historicalChart/historicalModal.tsx
@@ -2,7 +2,7 @@ import { Modal } from '@patternfly/react-core';
 import { getQuery, Query } from 'api/queries/query';
 import { ReportPathsType } from 'api/reports/report';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
@@ -25,7 +25,7 @@ interface HistoricalCloudModalStateProps {
 
 type HistoricalCloudModalProps = HistoricalCloudModalOwnProps &
   HistoricalCloudModalStateProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 class HistoricalCloudModalBase extends React.Component<
   HistoricalCloudModalProps
@@ -65,7 +65,7 @@ class HistoricalCloudModalBase extends React.Component<
   };
 
   public render() {
-    const { groupBy, isOpen, item, t } = this.props;
+    const { groupBy, isOpen, item, intl } = this.props;
 
     return (
       <Modal
@@ -73,10 +73,13 @@ class HistoricalCloudModalBase extends React.Component<
         isLarge
         isOpen={isOpen}
         onClose={this.handleClose}
-        title={t('details.historical.modal_title', {
-          groupBy,
-          name: item.label,
-        })}
+        title={intl.formatMessage(
+          { id: 'details.historical.modal_title' },
+          {
+            groupBy,
+            name: item.label,
+          }
+        )}
       >
         {this.getChart()}
       </Modal>
@@ -118,7 +121,7 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const HistoricalModal = translate()(
+const HistoricalModal = injectIntl(
   connect(mapStateToProps, {})(HistoricalCloudModalBase)
 );
 

--- a/src/pages/details/components/nav/tertiaryNav.tsx
+++ b/src/pages/details/components/nav/tertiaryNav.tsx
@@ -1,6 +1,6 @@
 import { Nav, NavItem, NavList, NavVariants } from '@patternfly/react-core';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { RouteComponentProps } from 'react-router';
 import { withRouter } from 'react-router-dom';
 
@@ -27,7 +27,7 @@ interface AvailableNavItem {
 }
 
 type TertiaryNavProps = TertiaryNavOwnProps &
-  InjectedTranslateProps &
+  WrappedComponentProps &
   RouteComponentProps<void>;
 
 export class TertiaryNavBase extends React.Component<TertiaryNavProps> {
@@ -44,12 +44,12 @@ export class TertiaryNavBase extends React.Component<TertiaryNavProps> {
   };
 
   private getNavItemTitle = (navItem: TertiaryNavItem) => {
-    const { t } = this.props;
+    const { intl } = this.props;
 
     if (navItem === TertiaryNavItem.aws) {
-      return t('aws_details.title');
+      return intl.formatMessage({ id: 'aws_details.title' });
     } else if (navItem === TertiaryNavItem.azure) {
-      return t('azure_details.title');
+      return intl.formatMessage({ id: 'azure_details.title' });
     }
   };
 
@@ -101,6 +101,6 @@ export class TertiaryNavBase extends React.Component<TertiaryNavProps> {
   }
 }
 
-const TertiaryNav = withRouter(translate()(TertiaryNavBase));
+const TertiaryNav = withRouter(injectIntl(TertiaryNavBase));
 
 export { TertiaryNav };

--- a/src/pages/details/components/priceList/noRatesState.tsx
+++ b/src/pages/details/components/priceList/noRatesState.tsx
@@ -7,23 +7,27 @@ import {
 } from '@patternfly/react-core';
 import { MoneyCheckAltIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { styles } from './noRatesState.styles';
 
-interface Props extends InjectedTranslateProps {
+interface Props extends WrappedComponentProps {
   cluster: string;
 }
 
-const NoRatesStateBase: React.SFC<Props> = ({ t, cluster }) => {
+const NoRatesStateBase: React.SFC<Props> = ({ intl, cluster }) => {
   return (
     <div style={styles.container}>
       <PfEmptyState>
         <EmptyStateIcon icon={MoneyCheckAltIcon} />
-        <Title size={TitleSize.lg}>{t('no_rates_state.title')}</Title>
-        <EmptyStateBody>{t('no_rates_state.desc', { cluster })}</EmptyStateBody>
+        <Title size={TitleSize.lg}>
+          {intl.formatMessage({ id: 'no_rates_state.title' })}
+        </Title>
+        <EmptyStateBody>
+          {intl.formatMessage({ id: 'no_rates_state.desc' }, { cluster })}
+        </EmptyStateBody>
       </PfEmptyState>
     </div>
   );
 };
 
-export const NoRatesState = translate()(NoRatesStateBase);
+export const NoRatesState = injectIntl(NoRatesStateBase);

--- a/src/pages/details/components/priceList/priceListModal.tsx
+++ b/src/pages/details/components/priceList/priceListModal.tsx
@@ -7,16 +7,16 @@ import { ProviderType } from 'api/providers';
 import { AxiosError } from 'axios';
 import { ErrorState } from 'components/state/errorState/errorState';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { priceListActions, priceListSelectors } from 'store/priceList';
 import { providersSelectors } from 'store/providers';
+import { intl } from '../../../../components/i18nProvider';
 import { NoRatesState } from './noRatesState';
 import { modalOverride, styles } from './priceListModal.styles';
 import PriceListTable from './priceListTable';
 
-interface Props extends InjectedTranslateProps {
+interface Props {
   isOpen: boolean;
   close: (isOpen: boolean) => void;
   fetch: typeof priceListActions.fetchPriceList;
@@ -44,7 +44,6 @@ class PriceListModalBase extends React.Component<Props> {
 
   public renderContent() {
     const {
-      t,
       providers,
       name,
       priceListStatus,
@@ -63,21 +62,24 @@ class PriceListModalBase extends React.Component<Props> {
     const priceListRates =
       priceListProvider && priceList[priceListProvider.uuid];
     return priceListRates ? (
-      <PriceListTable t={t} rates={priceListRates} />
+      <PriceListTable intl={intl} rates={priceListRates} />
     ) : (
       <NoRatesState cluster={name.toString()} />
     );
   }
 
   public render() {
-    const { t, isOpen, close, name } = this.props;
+    const { isOpen, close, name } = this.props;
 
     return (
       <Modal
         className={modalOverride}
         isOpen={isOpen}
         onClose={() => close(false)}
-        title={t('details.price_list.modal.title', { name })}
+        title={intl.formatMessage(
+          { id: 'details.price_list.modal.title' },
+          { name }
+        )}
       >
         {this.renderContent()}
       </Modal>
@@ -104,6 +106,6 @@ const PriceListModal = connect(
   {
     fetch: priceListActions.fetchPriceList,
   }
-)(translate()(PriceListModalBase));
+)(PriceListModalBase);
 
 export { PriceListModal };

--- a/src/pages/details/components/priceList/priceListTable.tsx
+++ b/src/pages/details/components/priceList/priceListTable.tsx
@@ -2,35 +2,44 @@ import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import React from 'react';
 import { formatCurrency } from 'utils/formatValue';
 
-function getUsageRangeText(metric, t) {
+function getUsageRangeText(metric, intl) {
   return metric.range_value[0] === null && metric.range_value[1] === null
-    ? t('details.price_list.modal.no_range_set')
+    ? intl.formatMessage({ id: 'details.price_list.modal.no_range_set' })
     : `${metric.range_value[0] || ' '} - ${metric.range_value[2] || ' '} ${
         metric.range_unit
       }`;
 }
 
-const PriceListTable = ({ rates, t }) => {
-  const notAvailableText = t('details.price_list.modal.not_available');
+const PriceListTable = ({ rates, intl }) => {
+  const notAvailableText = intl.formatMessage({
+    id: 'details.price_list.modal.not_available',
+  });
   return (
     <Table
       aria-label="price-list-table"
       cells={[
-        t('details.price_list.modal.metric'),
-        t('details.price_list.modal.value'),
-        t('details.price_list.modal.applied_usage_range'),
-        t('details.price_list.modal.applied_usage_date_range'),
+        intl.formatMessage({ id: 'details.price_list.modal.metric' }),
+        intl.formatMessage({ id: 'details.price_list.modal.value' }),
+        intl.formatMessage({
+          id: 'details.price_list.modal.applied_usage_range',
+        }),
+        intl.formatMessage({
+          id: 'details.price_list.modal.applied_usage_date_range',
+        }),
       ]}
       rows={rates.map(metric => [
-        t(`details.price_list.modal.${metric.display}`, {
-          index: metric.index + 1,
-          unit: metric.range_unit,
-        }),
+        intl.formatMessage(
+          { id: `details.price_list.modal.${metric.display}` },
+          {
+            index: metric.index + 1,
+            unit: metric.range_unit,
+          }
+        ),
         metric.value
           ? formatCurrency(metric.value, metric.value_unit)
           : notAvailableText,
-        getUsageRangeText(metric, t),
-        t(`details.price_list.modal.${metric.period}`),
+        getUsageRangeText(metric, intl),
+        intl.formatMessage({ id: `details.price_list.modal.${metric.period}` }),
       ])}
     >
       <TableHeader />

--- a/src/pages/details/components/summary/summary.tsx
+++ b/src/pages/details/components/summary/summary.tsx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from '@patternfly/react-core';
 import { ReportPathsType } from 'api/reports/report';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { SummaryView } from './summaryView';
 
@@ -17,7 +17,7 @@ interface SummaryState {
   activeTabKey: number;
 }
 
-type SummaryProps = SummaryOwnProps & InjectedTranslateProps;
+type SummaryProps = SummaryOwnProps & WrappedComponentProps;
 
 class SummaryBase extends React.Component<SummaryProps> {
   public state: SummaryState = {
@@ -97,10 +97,10 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   private getTabTitle = (tab: string) => {
-    const { getIdKeyForTab, t } = this.props;
+    const { getIdKeyForTab, intl } = this.props;
     const key = getIdKeyForTab(tab) || '';
 
-    return t('group_by.details', { groupBy: key });
+    return intl.formatMessage({ id: 'group_by.details' }, { groupBy: key });
   };
 
   public render() {
@@ -108,6 +108,6 @@ class SummaryBase extends React.Component<SummaryProps> {
   }
 }
 
-const Summary = translate()(SummaryBase);
+const Summary = injectIntl(SummaryBase);
 
 export { Summary, SummaryProps };

--- a/src/pages/details/components/summary/summaryModal.tsx
+++ b/src/pages/details/components/summary/summaryModal.tsx
@@ -1,7 +1,7 @@
 import { Modal } from '@patternfly/react-core';
 import { ReportPathsType } from 'api/reports/report';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { modalOverride } from './summaryModal.styles';
 import { SummaryModalView } from './summaryModalView';
@@ -15,7 +15,7 @@ interface SummaryModalOwnProps {
   reportPathsType: ReportPathsType;
 }
 
-type SummaryModalProps = SummaryModalOwnProps & InjectedTranslateProps;
+type SummaryModalProps = SummaryModalOwnProps & WrappedComponentProps;
 
 class SummaryModalBase extends React.Component<SummaryModalProps> {
   constructor(props: SummaryModalProps) {
@@ -39,7 +39,7 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
       item,
       parentGroupBy,
       reportPathsType,
-      t,
+      intl,
     } = this.props;
 
     return (
@@ -48,10 +48,13 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
         isLarge
         isOpen={isOpen}
         onClose={this.handleClose}
-        title={t('details.summary_modal_title', {
-          groupBy,
-          name: item.label,
-        })}
+        title={intl.formatMessage(
+          { id: 'details.summary_modal_title' },
+          {
+            groupBy,
+            name: item.label,
+          }
+        )}
       >
         <SummaryModalView
           groupBy={groupBy}
@@ -64,6 +67,6 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
   }
 }
 
-const SummaryModal = translate()(SummaryModalBase);
+const SummaryModal = injectIntl(SummaryModalBase);
 
 export { SummaryModal };

--- a/src/pages/details/components/summary/summaryModalView.tsx
+++ b/src/pages/details/components/summary/summaryModalView.tsx
@@ -6,7 +6,7 @@ import {
   ReportSummaryItems,
 } from 'components/reports/reportSummary';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -35,7 +35,7 @@ interface SummaryModalViewDispatchProps {
 type SummaryModalViewProps = SummaryModalViewOwnProps &
   SummaryModalViewStateProps &
   SummaryModalViewDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const reportType = ReportType.cost;
 
@@ -57,7 +57,7 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
   }
 
   public render() {
-    const { groupBy, report, reportFetchStatus, t } = this.props;
+    const { groupBy, report, reportFetchStatus, intl } = this.props;
 
     const cost = formatCurrency(
       report && report.meta && report.meta.total
@@ -68,7 +68,9 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
     return (
       <>
         <div style={styles.subTitle}>
-          <Title size="lg">{t('details.cost_value', { value: cost })}</Title>
+          <Title size="lg">
+            {intl.formatMessage({ id: 'details.cost_value' }, { value: cost })}
+          </Title>
         </div>
         <div style={styles.mainContent}>
           <ReportSummaryItems
@@ -133,7 +135,7 @@ const mapDispatchToProps: SummaryModalViewDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const SummaryModalView = translate()(
+const SummaryModalView = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(SummaryModalViewBase)
 );
 

--- a/src/pages/details/components/summary/summaryView.tsx
+++ b/src/pages/details/components/summary/summaryView.tsx
@@ -11,7 +11,7 @@ import {
   ReportSummaryItems,
 } from 'components/reports/reportSummary';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -50,7 +50,7 @@ interface SummaryViewDispatchProps {
 type SummaryViewProps = SummaryViewOwnProps &
   SummaryViewStateProps &
   SummaryViewDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const reportType = ReportType.cost;
 
@@ -108,7 +108,7 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
   };
 
   private getViewAll = () => {
-    const { groupBy, item, parentGroupBy, reportPathsType, t } = this.props;
+    const { groupBy, item, parentGroupBy, reportPathsType, intl } = this.props;
     const { isSummaryModalOpen } = this.state;
     const computedItems = this.getItems();
 
@@ -128,7 +128,7 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
             type={ButtonType.button}
             variant={ButtonVariant.link}
           >
-            {t('details.view_all', { groupBy })}
+            {intl.formatMessage({ id: 'details.view_all' }, { groupBy })}
           </Button>
           <SummaryModal
             groupBy={groupBy}
@@ -226,7 +226,7 @@ const mapDispatchToProps: SummaryViewDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const SummaryView = translate()(
+const SummaryView = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(SummaryViewBase)
 );
 

--- a/src/pages/details/components/tag/tag.tsx
+++ b/src/pages/details/components/tag/tag.tsx
@@ -2,7 +2,7 @@ import { getQuery } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -37,7 +37,7 @@ interface TagDispatchProps {
 type TagProps = TagOwnProps &
   TagStateProps &
   TagDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const reportType = ReportType.tag;
 
@@ -84,7 +84,7 @@ class TagBase extends React.Component<TagProps> {
       item,
       report,
       reportPathsType,
-      t,
+      intl,
     } = this.props;
     const { isOpen, showAll } = this.state;
 
@@ -128,9 +128,12 @@ class TagBase extends React.Component<TagProps> {
             href="#/"
             onClick={this.handleOpen}
           >
-            {t('details.more_tags', {
-              value: allTags.length - someTags.length,
-            })}
+            {intl.formatMessage(
+              { id: 'details.more_tags' },
+              {
+                value: allTags.length - someTags.length,
+              }
+            )}
           </a>
         )}
         <TagModal
@@ -181,6 +184,6 @@ const mapDispatchToProps: TagDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const Tag = translate()(connect(mapStateToProps, mapDispatchToProps)(TagBase));
+const Tag = injectIntl(connect(mapStateToProps, mapDispatchToProps)(TagBase));
 
 export { Tag, TagProps };

--- a/src/pages/details/components/tag/tagModal.tsx
+++ b/src/pages/details/components/tag/tagModal.tsx
@@ -1,7 +1,7 @@
 import { Modal } from '@patternfly/react-core';
 import { ReportPathsType } from 'api/reports/report';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { modalOverride } from './tagModal.styles';
 import { TagView } from './tagView';
@@ -15,7 +15,7 @@ interface TagModalOwnProps {
   reportPathsType: ReportPathsType;
 }
 
-type TagModalProps = TagModalOwnProps & InjectedTranslateProps;
+type TagModalProps = TagModalOwnProps & WrappedComponentProps;
 
 class TagModalBase extends React.Component<TagModalProps> {
   constructor(props: TagModalProps) {
@@ -33,17 +33,20 @@ class TagModalBase extends React.Component<TagModalProps> {
   };
 
   public render() {
-    const { groupBy, isOpen, item, reportPathsType, t } = this.props;
+    const { groupBy, isOpen, item, reportPathsType, intl } = this.props;
 
     return (
       <Modal
         className={modalOverride}
         isOpen={isOpen}
         onClose={this.handleClose}
-        title={t('details.tags_modal_title', {
-          groupBy,
-          name: item.label,
-        })}
+        title={intl.formatMessage(
+          { id: 'details.tags_modal_title' },
+          {
+            groupBy,
+            name: item.label,
+          }
+        )}
         width={'50%'}
       >
         <TagView
@@ -57,6 +60,6 @@ class TagModalBase extends React.Component<TagModalProps> {
   }
 }
 
-const TagModal = translate()(TagModalBase);
+const TagModal = injectIntl(TagModalBase);
 
 export { TagModal };

--- a/src/pages/details/components/tag/tagView.tsx
+++ b/src/pages/details/components/tag/tagView.tsx
@@ -2,7 +2,7 @@ import { getQuery } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -28,7 +28,7 @@ interface TagViewDispatchProps {
 type TagViewProps = TagViewOwnProps &
   TagViewStateProps &
   TagViewDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const reportType = ReportType.tag;
 
@@ -103,7 +103,7 @@ const mapDispatchToProps: TagViewDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const TagView = translate()(
+const TagView = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(TagViewBase)
 );
 

--- a/src/pages/details/components/toolbar/toolbar.tsx
+++ b/src/pages/details/components/toolbar/toolbar.tsx
@@ -25,7 +25,7 @@ import { Query, tagKeyPrefix } from 'api/queries/query';
 import { cloneDeep } from 'lodash';
 import { uniq, uniqBy } from 'lodash';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { isEqual } from 'utils/equal';
 import { styles } from './toolbar.styles';
@@ -59,7 +59,7 @@ interface ToolbarState {
   tagKeyValueInput?: string;
 }
 
-type ToolbarProps = ToolbarOwnProps & InjectedTranslateProps;
+type ToolbarProps = ToolbarOwnProps & WrappedComponentProps;
 
 const defaultFilters = {
   tag: {},
@@ -272,7 +272,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
   // Category input
 
   public getCategoryInput = categoryOption => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const { currentCategory, filters, categoryInput } = this.state;
 
     return (
@@ -288,15 +288,21 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
             name={`${categoryOption.key}-input`}
             id={`${categoryOption.key}-input`}
             type="search"
-            aria-label={t(`filter_by.${categoryOption.key}_input_aria_label`)}
+            aria-label={intl.formatMessage({
+              id: `filter_by.${categoryOption.key}_input_aria_label`,
+            })}
             onChange={this.onCategoryInputChange}
             value={categoryInput}
-            placeholder={t(`filter_by.${categoryOption.key}_placeholder`)}
+            placeholder={intl.formatMessage({
+              id: `filter_by.${categoryOption.key}_placeholder`,
+            })}
             onKeyDown={evt => this.onCategoryInput(evt, categoryOption.key)}
           />
           <Button
             variant={ButtonVariant.control}
-            aria-label={t(`filter_by.${categoryOption.key}_button_aria_label`)}
+            aria-label={intl.formatMessage({
+              id: `filter_by.${categoryOption.key}_button_aria_label`,
+            })}
             onClick={evt => this.onCategoryInput(evt, categoryOption.key)}
           >
             <SearchIcon />
@@ -307,9 +313,14 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
   };
 
   private getDefaultCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { t } = this.props;
+    const { intl } = this.props;
 
-    return [{ name: t('filter_by.values.name'), key: 'name' }];
+    return [
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.name' }),
+        key: 'name',
+      },
+    ];
   };
 
   private onCategoryInputChange = value => {
@@ -347,7 +358,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
   // Tag key select
 
   public getTagKeySelect = () => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const {
       currentCategory,
       currentTagKey,
@@ -366,12 +377,16 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
       <DataToolbarItem>
         <Select
           variant={SelectVariant.typeahead}
-          aria-label={t('filter_by.tag_key_aria_label')}
+          aria-label={intl.formatMessage({
+            id: 'filter_by.tag_key_aria_label',
+          })}
           onClear={this.onTagKeyClear}
           onToggle={this.onTagKeyToggle}
           onSelect={this.onTagKeySelect}
           isExpanded={isTagKeySelectExpanded}
-          placeholderText={t('filter_by.tag_key_placeholder')}
+          placeholderText={intl.formatMessage({
+            id: 'filter_by.tag_key_placeholder',
+          })}
           selections={currentTagKey}
         >
           {selectOptions}
@@ -442,7 +457,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
   // Tag value select
 
   public getTagValueSelect = tagKeyPrefixOption => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const {
       currentCategory,
       currentTagKey,
@@ -468,7 +483,9 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
         {Boolean(selectOptions.length < tagKeyValueLimit) ? (
           <Select
             variant={SelectVariant.checkbox}
-            aria-label={t('filter_by.tag_value_aria_label')}
+            aria-label={intl.formatMessage({
+              id: 'filter_by.tag_value_aria_label',
+            })}
             onToggle={this.onTagValueToggle}
             onSelect={this.onTagValueSelect}
             selections={
@@ -477,7 +494,9 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
                 : []
             }
             isExpanded={isTagValueSelectExpanded}
-            placeholderText={t('filter_by.tag_value_placeholder')}
+            placeholderText={intl.formatMessage({
+              id: 'filter_by.tag_value_placeholder',
+            })}
           >
             {selectOptions}
           </Select>
@@ -487,15 +506,21 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
               name="tagkeyvalue-input"
               id="tagkeyvalue-input"
               type="search"
-              aria-label={t('filter_by.tag_value_aria_label')}
+              aria-label={intl.formatMessage({
+                id: 'filter_by.tag_value_aria_label',
+              })}
               onChange={this.onTagValueInputChange}
               value={tagKeyValueInput}
-              placeholder={t('filter_by.tag_value_input_placeholder')}
+              placeholder={intl.formatMessage({
+                id: 'filter_by.tag_value_input_placeholder',
+              })}
               onKeyDown={evt => this.onTagValueInput(evt)}
             />
             <Button
               variant={ButtonVariant.control}
-              aria-label={t('filter_by.tag_value_button_aria_label')}
+              aria-label={intl.formatMessage({
+                id: 'filter_by.tag_value_button_aria_label',
+              })}
               onClick={evt => this.onTagValueInput(evt)}
             >
               <SearchIcon />
@@ -675,6 +700,6 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
   }
 }
 
-const Toolbar = translate()(connect()(ToolbarBase));
+const Toolbar = injectIntl(connect()(ToolbarBase));
 
 export { Toolbar, ToolbarProps, Filters };

--- a/src/pages/details/ocpCloudDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsHeader.tsx
@@ -9,7 +9,11 @@ import { AxiosError } from 'axios';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import {
+  FormattedMessage,
+  injectIntl,
+  WrappedComponentProps,
+} from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ocpProvidersQuery, providersSelectors } from 'store/providers';
@@ -40,7 +44,7 @@ interface DetailsHeaderState {
 
 type DetailsHeaderProps = DetailsHeaderOwnProps &
   DetailsHeaderStateProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const baseQuery: OcpCloudQuery = {
   delta: 'cost',
@@ -81,7 +85,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers,
       providersError,
       report,
-      t,
+      intl,
     } = this.props;
     const showContent =
       report &&
@@ -116,7 +120,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       <header style={styles.header}>
         <div>
           <Title style={styles.title} size={TitleSize['2xl']}>
-            {t('ocp_cloud_details.title')}
+            {intl.formatMessage({ id: 'ocp_cloud_details.title' })}
           </Title>
           <GroupBy
             getIdKeyForGroupBy={getIdKeyForGroupBy}
@@ -131,9 +135,14 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <div style={styles.cost}>
             <Title style={styles.costValue} size="4xl">
               <Tooltip
-                content={t('ocp_cloud_details.total_cost_tooltip', {
-                  infrastructureCost,
-                })}
+                content={
+                  <FormattedMessage
+                    id="ocp_cloud_details.total_cost_tooltip"
+                    values={{
+                      infrastructureCost,
+                    }}
+                  />
+                }
                 enableFlip
               >
                 <span>{cost}</span>
@@ -141,17 +150,25 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             </Title>
             <div style={styles.costLabel}>
               <div style={styles.costLabelUnit}>
-                {t('ocp_cloud_details.total_cost')}
+                {intl.formatMessage({ id: 'ocp_cloud_details.total_cost' })}
                 <span style={styles.infoIcon}>
                   <Popover
-                    aria-label="t('ocp_cloud_details.markup_aria_label')"
+                    aria-label={intl.formatMessage({
+                      id: 'ocp_cloud_details.markup_aria_label',
+                    })}
                     enableFlip
                     bodyContent={
                       <>
                         <p style={styles.infoTitle}>
-                          {t('ocp_cloud_details.infrastructure_cost_title')}
+                          {intl.formatMessage({
+                            id: 'ocp_cloud_details.infrastructure_cost_title',
+                          })}
                         </p>
-                        <p>{t('ocp_cloud_details.infrastructure_cost_desc')}</p>
+                        <p>
+                          {intl.formatMessage({
+                            id: 'ocp_cloud_details.infrastructure_cost_desc',
+                          })}
+                        </p>
                       </>
                     }
                   >
@@ -203,7 +220,7 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const DetailsHeader = translate()(
+const DetailsHeader = injectIntl(
   connect(mapStateToProps, {})(DetailsHeaderBase)
 );
 

--- a/src/pages/details/ocpCloudDetails/detailsSummary.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsSummary.tsx
@@ -30,7 +30,7 @@ export const enum OcpCloudDetailsTab {
 
 const DetailsSummary: React.SFC<Omit<
   SummaryProps,
-  'availableTabs' | 'getIdKeyForTab' | 't'
+  'availableTabs' | 'getIdKeyForTab' | 'intl'
 >> = props => (
   <Summary
     availableTabs={[

--- a/src/pages/details/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsTable.tsx
@@ -19,7 +19,7 @@ import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterS
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { Actions } from 'pages/details/components/actions/actions';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOcpCloudReportItems';
 import {
@@ -52,7 +52,7 @@ interface DetailsTableState {
   rows?: any[];
 }
 
-type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
+type DetailsTableProps = DetailsTableOwnProps & WrappedComponentProps;
 
 const reportPathsType = ReportPathsType.ocpCloud;
 
@@ -91,7 +91,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   private initDatum = () => {
-    const { query, report, t } = this.props;
+    const { query, report, intl } = this.props;
     if (!query || !report) {
       return;
     }
@@ -112,14 +112,21 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const columns = groupByTagKey
       ? [
           {
-            title: t('ocp_cloud_details.tag_column_title'),
+            title: intl.formatMessage({
+              id: 'ocp_cloud_details.tag_column_title',
+            }),
           },
           {
-            title: t('ocp_cloud_details.change_column_title'),
+            title: intl.formatMessage({
+              id: 'ocp_cloud_details.change_column_title',
+            }),
           },
           {
             orderBy: 'cost',
-            title: t('ocp_cloud_details.cost_column_title', { total }),
+            title: intl.formatMessage(
+              { id: 'ocp_cloud_details.cost_column_title' },
+              { total }
+            ),
             transforms: [sortable],
           },
           {
@@ -129,17 +136,24 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       : [
           {
             orderBy: groupById,
-            title: t('ocp_cloud_details.name_column_title', {
-              groupBy: groupById,
-            }),
+            title: intl.formatMessage(
+              { id: 'ocp_cloud_details.name_column_title' },
+              {
+                groupBy: groupById,
+              }
+            ),
             transforms: [sortable],
           },
           {
-            title: t('ocp_cloud_details.change_column_title'),
+            title: intl.formatMessage({
+              id: 'ocp_cloud_details.change_column_title',
+            }),
           },
           {
             orderBy: 'cost',
-            title: t('ocp_cloud_details.cost_column_title'),
+            title: intl.formatMessage({
+              id: 'ocp_cloud_details.cost_column_title',
+            }),
             transforms: [sortable],
           },
           {
@@ -182,7 +196,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           parent: index * 2,
           cells: [
             {
-              title: <div key={`${index * 2}-child`}>{t('loading')}</div>,
+              title: (
+                <div key={`${index * 2}-child`}>
+                  {intl.formatMessage({ id: 'loading' })}
+                </div>
+              ),
             },
           ],
         }
@@ -215,7 +233,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getEmptyState = () => {
-    const { query, t } = this.props;
+    const { query, intl } = this.props;
 
     for (const val of Object.values(query.group_by)) {
       if (val !== '*') {
@@ -225,7 +243,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{t('ocp_cloud_details.empty_state')}</EmptyStateBody>
+        <EmptyStateBody>
+          {intl.formatMessage({ id: 'ocp_cloud_details.empty_state' })}
+        </EmptyStateBody>
       </EmptyState>
     );
   };
@@ -247,7 +267,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
@@ -273,7 +293,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <div className={monthOverMonthOverride}>
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
             {Boolean(showPercentage) ? (
-              t('percent', { value: percentage })
+              intl.formatMessage({ id: 'percent' }, { value: percentage })
             ) : (
               <EmptyValueState />
             )}
@@ -352,7 +372,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getTotalCost = (item: ComputedReportItem, index: number) => {
-    const { report, t } = this.props;
+    const { report, intl } = this.props;
     const cost =
       report &&
       report.meta &&
@@ -366,16 +386,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.cost)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {t('percent_of_cost', {
-            value: ((item.cost / cost) * 100).toFixed(2),
-          })}
+          {intl.formatMessage(
+            { id: 'percent_of_cost' },
+            {
+              value: ((item.cost / cost) * 100).toFixed(2),
+            }
+          )}
         </div>
       </>
     );
   };
 
   private handleOnCollapse = (event, rowId, isOpen) => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const { rows } = this.state;
     const {
       tableItem: { item, groupBy, query, index },
@@ -387,7 +410,13 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ];
     } else {
       rows[rowId + 1].cells = [
-        { title: <div key={`${index * 2}-child`}>{t('loading')}</div> },
+        {
+          title: (
+            <div key={`${index * 2}-child`}>
+              {intl.formatMessage({ id: 'loading' })}
+            </div>
+          ),
+        },
       ];
     }
     rows[rowId].isOpen = isOpen;
@@ -461,6 +490,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 }
 
-const DetailsTable = translate()(connect()(DetailsTableBase));
+const DetailsTable = injectIntl(connect()(DetailsTableBase));
 
 export { DetailsTable, DetailsTableProps };

--- a/src/pages/details/ocpCloudDetails/detailsTableItem.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsTableItem.tsx
@@ -13,7 +13,7 @@ import { Cluster } from 'pages/details/components/cluster/cluster';
 import { HistoricalModal } from 'pages/details/components/historicalChart/historicalModal';
 import { Tag } from 'pages/details/components/tag/tag';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { getTestProps, testIds } from 'testIds';
@@ -31,7 +31,7 @@ interface DetailsTableItemState {
   isHistoricalModalOpen: boolean;
 }
 
-type DetailsTableItemProps = DetailsTableItemOwnProps & InjectedTranslateProps;
+type DetailsTableItemProps = DetailsTableItemOwnProps & WrappedComponentProps;
 
 const reportPathsType = ReportPathsType.ocpCloud;
 
@@ -57,7 +57,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
   };
 
   public render() {
-    const { item, groupBy, t } = this.props;
+    const { item, groupBy, intl } = this.props;
     const { isHistoricalModalOpen } = this.state;
 
     return (
@@ -71,7 +71,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 type={ButtonType.button}
                 variant={ButtonVariant.secondary}
               >
-                {t('ocp_cloud_details.historical.view_data')}
+                {intl.formatMessage({
+                  id: 'ocp_cloud_details.historical.view_data',
+                })}
               </Button>
             </div>
           </GridItem>
@@ -81,7 +83,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 <div style={styles.clusterContainer}>
                   <Form>
                     <FormGroup
-                      label={t('ocp_cloud_details.cluster_label')}
+                      label={intl.formatMessage({
+                        id: 'ocp_cloud_details.cluster_label',
+                      })}
                       fieldId="cluster-name"
                     >
                       <Cluster groupBy={groupBy} item={item} />
@@ -102,7 +106,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 <div style={styles.tagsContainer}>
                   <Form>
                     <FormGroup
-                      label={t('ocp_cloud_details.tags_label')}
+                      label={intl.formatMessage({
+                        id: 'ocp_cloud_details.tags_label',
+                      })}
                       fieldId="tags"
                     >
                       <Tag
@@ -143,7 +149,7 @@ const mapStateToProps = createMapStateToProps<DetailsTableItemOwnProps, {}>(
   }
 );
 
-const DetailsTableItem = translate()(
+const DetailsTableItem = injectIntl(
   connect(mapStateToProps, {})(DetailsTableItemBase)
 );
 

--- a/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
@@ -4,7 +4,7 @@ import { OcpCloudReport } from 'api/reports/ocpCloudReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -38,7 +38,7 @@ interface DetailsToolbarState {
 type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarStateProps &
   DetailsToolbarDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.ocpCloud;
@@ -68,13 +68,22 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report, t } = this.props;
+    const { report, intl } = this.props;
 
     const options = [
-      { name: t('filter_by.values.cluster'), key: 'cluster' },
-      { name: t('filter_by.values.node'), key: 'node' },
-      { name: t('filter_by.values.project'), key: 'project' },
-      { name: t('filter_by.values.tag'), key: 'tag' },
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.cluster' }),
+        key: 'cluster',
+      },
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.node' }),
+        key: 'node',
+      },
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.project' }),
+        key: 'project',
+      },
+      { name: intl.formatMessage({ id: 'filter_by.values.tag' }), key: 'tag' },
     ];
 
     return report && report.data && report.data.length
@@ -147,7 +156,7 @@ const mapDispatchToProps: DetailsToolbarDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const DetailsToolbar = translate()(
+const DetailsToolbar = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(DetailsToolbarBase)
 );
 

--- a/src/pages/details/ocpCloudDetails/historicalChart.tsx
+++ b/src/pages/details/ocpCloudDetails/historicalChart.tsx
@@ -15,7 +15,7 @@ import {
   styles,
 } from 'pages/details/components/historicalChart/historicalChart.styles';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -52,7 +52,7 @@ interface HistoricalModalDispatchProps {
 type HistoricalModalProps = HistoricalModalOwnProps &
   HistoricalModalStateProps &
   HistoricalModalDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const cpuReportType = ReportType.cpu;
 const costReportType = ReportType.cost;
@@ -109,7 +109,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
       previousCpuReportFetchStatus,
       previousMemoryReport,
       previousMemoryReportFetchStatus,
-      t,
+      intl,
     } = this.props;
 
     // Cost data
@@ -238,11 +238,20 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
               formatDatumOptions={{}}
               height={chartStyles.chartHeight}
               previousData={previousCostData}
-              title={t('ocp_cloud_details.historical.cost_title')}
-              xAxisLabel={t('ocp_cloud_details.historical.day_of_month_label')}
-              yAxisLabel={t('ocp_details.historical.cost_label', {
-                units: t(`units.${unitLookupKey(costUnits)}`),
+              title={intl.formatMessage({
+                id: 'ocp_cloud_details.historical.cost_title',
               })}
+              xAxisLabel={intl.formatMessage({
+                id: 'ocp_cloud_details.historical.day_of_month_label',
+              })}
+              yAxisLabel={intl.formatMessage(
+                { id: 'ocp_details.historical.cost_label' },
+                {
+                  units: intl.formatMessage({
+                    id: `units.${unitLookupKey(costUnits)}`,
+                  }),
+                }
+              )}
             />
           )}
         </div>
@@ -262,11 +271,20 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
               previousLimitData={previousCpuLimitData}
               previousRequestData={previousCpuRequestData}
               previousUsageData={previousCpuUsageData}
-              title={t('ocp_cloud_details.historical.cpu_title')}
-              xAxisLabel={t('ocp_cloud_details.historical.day_of_month_label')}
-              yAxisLabel={t('ocp_details.historical.cpu_label', {
-                units: t(`units.${unitLookupKey(cpuUnits)}`),
+              title={intl.formatMessage({
+                id: 'ocp_cloud_details.historical.cpu_title',
               })}
+              xAxisLabel={intl.formatMessage({
+                id: 'ocp_cloud_details.historical.day_of_month_label',
+              })}
+              yAxisLabel={intl.formatMessage(
+                { id: 'ocp_details.historical.cpu_label' },
+                {
+                  units: intl.formatMessage({
+                    id: `units.${unitLookupKey(cpuUnits)}`,
+                  }),
+                }
+              )}
             />
           )}
         </div>
@@ -286,11 +304,20 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
               previousLimitData={previousMemoryLimitData}
               previousRequestData={previousMemoryRequestData}
               previousUsageData={previousMemoryUsageData}
-              title={t('ocp_cloud_details.historical.memory_title')}
-              xAxisLabel={t('ocp_cloud_details.historical.day_of_month_label')}
-              yAxisLabel={t('ocp_details.historical.memory_label', {
-                units: t(`units.${unitLookupKey(memoryUnits)}`),
+              title={intl.formatMessage({
+                id: 'ocp_cloud_details.historical.memory_title',
               })}
+              xAxisLabel={intl.formatMessage({
+                id: 'ocp_cloud_details.historical.day_of_month_label',
+              })}
+              yAxisLabel={intl.formatMessage(
+                { id: 'ocp_details.historical.memory_label' },
+                {
+                  units: intl.formatMessage({
+                    id: `units.${unitLookupKey(memoryUnits)}`,
+                  }),
+                }
+              )}
             />
           )}
         </div>
@@ -398,7 +425,7 @@ const mapDispatchToProps: HistoricalModalDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const HistoricalChart = translate()(
+const HistoricalChart = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(HistoricalModalBase)
 );
 

--- a/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
+++ b/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
@@ -16,7 +16,7 @@ import { LoadingState } from 'components/state/loadingState/loadingState';
 import { NoProvidersState } from 'components/state/noProvidersState/noProvidersState';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -55,7 +55,7 @@ interface OcpCloudDetailsState {
 }
 
 type OcpCloudDetailsOwnProps = RouteComponentProps<void> &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 type OcpCloudDetailsProps = OcpCloudDetailsStateProps &
   OcpCloudDetailsOwnProps &
@@ -499,6 +499,6 @@ const mapDispatchToProps: OcpCloudDetailsDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-export default translate()(
+export default injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(OcpCloudDetails)
 );

--- a/src/pages/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpDetails/detailsHeader.tsx
@@ -9,7 +9,11 @@ import { AxiosError } from 'axios';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import {
+  FormattedMessage,
+  injectIntl,
+  WrappedComponentProps,
+} from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ocpProvidersQuery, providersSelectors } from 'store/providers';
@@ -40,7 +44,7 @@ interface DetailsHeaderState {
 
 type DetailsHeaderProps = DetailsHeaderOwnProps &
   DetailsHeaderStateProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const baseQuery: OcpQuery = {
   delta: 'cost',
@@ -81,7 +85,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers,
       providersError,
       report,
-      t,
+      intl,
     } = this.props;
     const showContent =
       report &&
@@ -126,7 +130,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       <header style={styles.header}>
         <div>
           <Title style={styles.title} size={TitleSize['2xl']}>
-            {t('ocp_details.title')}
+            {intl.formatMessage({ id: 'ocp_details.title' })}
           </Title>
           <GroupBy
             getIdKeyForGroupBy={getIdKeyForGroupBy}
@@ -141,10 +145,15 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <div style={styles.cost}>
             <Title style={styles.costValue} size="4xl">
               <Tooltip
-                content={t('ocp_details.total_cost_tooltip', {
-                  supplementaryCost,
-                  infrastructureCost,
-                })}
+                content={
+                  <FormattedMessage
+                    id="ocp_details.total_cost_tooltip"
+                    values={{
+                      supplementaryCost,
+                      infrastructureCost,
+                    }}
+                  />
+                }
                 enableFlip
               >
                 <span>{cost}</span>
@@ -152,7 +161,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             </Title>
             <div style={styles.costLabel}>
               <div style={styles.costLabelUnit}>
-                {t('ocp_details.total_cost')}
+                {intl.formatMessage({ id: 'ocp_details.total_cost' })}
                 <span style={styles.infoIcon}>
                   <Popover
                     aria-label="t('ocp_details.supplementary_aria_label')"
@@ -160,14 +169,26 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
                     bodyContent={
                       <>
                         <p style={styles.infoTitle}>
-                          {t('ocp_details.supplementary_cost_title')}
+                          {intl.formatMessage({
+                            id: 'ocp_details.supplementary_cost_title',
+                          })}
                         </p>
-                        <p>{t('ocp_details.supplementary_cost_desc')}</p>
+                        <p>
+                          {intl.formatMessage({
+                            id: 'ocp_details.supplementary_cost_desc',
+                          })}
+                        </p>
                         <br />
                         <p style={styles.infoTitle}>
-                          {t('ocp_details.infrastructure_cost_title')}
+                          {intl.formatMessage({
+                            id: 'ocp_details.infrastructure_cost_title',
+                          })}
                         </p>
-                        <p>{t('ocp_details.infrastructure_cost_desc')}</p>
+                        <p>
+                          {intl.formatMessage({
+                            id: 'ocp_details.infrastructure_cost_desc',
+                          })}
+                        </p>
                       </>
                     }
                   >
@@ -219,7 +240,7 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const DetailsHeader = translate()(
+const DetailsHeader = injectIntl(
   connect(mapStateToProps, {})(DetailsHeaderBase)
 );
 

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -19,7 +19,7 @@ import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterS
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { Actions } from 'pages/details/components/actions/actions';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOcpReportItems';
 import {
@@ -52,7 +52,7 @@ interface DetailsTableState {
   rows?: any[];
 }
 
-type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
+type DetailsTableProps = DetailsTableOwnProps & WrappedComponentProps;
 
 const reportPathsType = ReportPathsType.ocp;
 
@@ -91,7 +91,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   private initDatum = () => {
-    const { query, report, t } = this.props;
+    const { query, report, intl } = this.props;
     if (!query || !report) {
       return;
     }
@@ -113,20 +113,29 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ? [
           // Sorting with tag keys is not supported
           {
-            title: t('ocp_details.tag_column_title'),
+            title: intl.formatMessage({ id: 'ocp_details.tag_column_title' }),
           },
           {
-            title: t('ocp_details.change_column_title'),
+            title: intl.formatMessage({
+              id: 'ocp_details.change_column_title',
+            }),
           },
           {
-            title: t('ocp_details.infrastructure_cost_column_title'),
+            title: intl.formatMessage({
+              id: 'ocp_details.infrastructure_cost_column_title',
+            }),
           },
           {
-            title: t('ocp_details.supplementary_cost_column_title'),
+            title: intl.formatMessage({
+              id: 'ocp_details.supplementary_cost_column_title',
+            }),
           },
           {
             orderBy: 'cost',
-            title: t('ocp_details.cost_column_title', { total }),
+            title: intl.formatMessage(
+              { id: 'ocp_details.cost_column_title' },
+              { total }
+            ),
             transforms: [sortable],
           },
           {
@@ -136,29 +145,38 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       : [
           {
             orderBy: groupById,
-            title: t('ocp_details.name_column_title', { groupBy: groupById }),
+            title: intl.formatMessage(
+              { id: 'ocp_details.name_column_title' },
+              { groupBy: groupById }
+            ),
             transforms: [sortable],
           },
           {
-            title: t('ocp_details.change_column_title'),
+            title: intl.formatMessage({
+              id: 'ocp_details.change_column_title',
+            }),
           },
           {
             orderBy: 'infrastructure_cost',
-            title: t('ocp_details.infrastructure_cost_column_title'),
+            title: intl.formatMessage({
+              id: 'ocp_details.infrastructure_cost_column_title',
+            }),
 
             // Sort by infrastructure_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // transforms: [sortable],
           },
           {
             orderBy: 'supplementary_cost',
-            title: t('ocp_details.supplementary_cost_column_title'),
+            title: intl.formatMessage({
+              id: 'ocp_details.supplementary_cost_column_title',
+            }),
 
             // Sort by supplementary_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // transforms: [sortable],
           },
           {
             orderBy: 'cost',
-            title: t('ocp_details.cost_column_title'),
+            title: intl.formatMessage({ id: 'ocp_details.cost_column_title' }),
             transforms: [sortable],
           },
           {
@@ -205,7 +223,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           parent: index * 2,
           cells: [
             {
-              title: <div key={`${index * 2}-child`}>{t('loading')}</div>,
+              title: (
+                <div key={`${index * 2}-child`}>
+                  {intl.formatMessage({ id: 'loading' })}
+                </div>
+              ),
             },
           ],
         }
@@ -239,7 +261,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getEmptyState = () => {
-    const { query, t } = this.props;
+    const { query, intl } = this.props;
 
     for (const val of Object.values(query.group_by)) {
       if (val !== '*') {
@@ -249,13 +271,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{t('ocp_cloud_details.empty_state')}</EmptyStateBody>
+        <EmptyStateBody>
+          {intl.formatMessage({ id: 'ocp_cloud_details.empty_state' })}
+        </EmptyStateBody>
       </EmptyState>
     );
   };
 
   private getSupplementaryCost = (item: ComputedReportItem, index: number) => {
-    const { report, t } = this.props;
+    const { report, intl } = this.props;
     const total =
       report &&
       report.meta &&
@@ -269,9 +293,12 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.supplementary)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {t('percent_of_cost', {
-            value: ((item.supplementary / total) * 100).toFixed(2),
-          })}
+          {intl.formatMessage(
+            { id: 'percent_of_cost' },
+            {
+              value: ((item.supplementary / total) * 100).toFixed(2),
+            }
+          )}
         </div>
       </>
     );
@@ -294,7 +321,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getInfrastructureCost = (item: ComputedReportItem, index: number) => {
-    const { report, t } = this.props;
+    const { report, intl } = this.props;
     const total =
       report &&
       report.meta &&
@@ -309,16 +336,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.infrastructure)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {t('percent_of_cost', {
-            value: ((item.infrastructure / total) * 100).toFixed(2),
-          })}
+          {intl.formatMessage(
+            { id: 'percent_of_cost' },
+            {
+              value: ((item.infrastructure / total) * 100).toFixed(2),
+            }
+          )}
         </div>
       </>
     );
   };
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
@@ -344,7 +374,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <div className={monthOverMonthOverride}>
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
             {Boolean(showPercentage) ? (
-              t('percent', { value: percentage })
+              intl.formatMessage({ id: 'percent' }, { value: percentage })
             ) : (
               <EmptyValueState />
             )}
@@ -423,7 +453,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getTotalCost = (item: ComputedReportItem, index: number) => {
-    const { report, t } = this.props;
+    const { report, intl } = this.props;
     const cost =
       report &&
       report.meta &&
@@ -437,16 +467,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.cost)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {t('percent_of_cost', {
-            value: ((item.cost / cost) * 100).toFixed(2),
-          })}
+          {intl.formatMessage(
+            { id: 'percent_of_cost' },
+            {
+              value: ((item.cost / cost) * 100).toFixed(2),
+            }
+          )}
         </div>
       </>
     );
   };
 
   private handleOnCollapse = (event, rowId, isOpen) => {
-    const { t } = this.props;
+    const { intl } = this.props;
     const { rows } = this.state;
     const {
       tableItem: { item, groupBy, query, index },
@@ -458,7 +491,13 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ];
     } else {
       rows[rowId + 1].cells = [
-        { title: <div key={`${index * 2}-child`}>{t('loading')}</div> },
+        {
+          title: (
+            <div key={`${index * 2}-child`}>
+              {intl.formatMessage({ id: 'loading' })}
+            </div>
+          ),
+        },
       ];
     }
     rows[rowId].isOpen = isOpen;
@@ -532,6 +571,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 }
 
-const DetailsTable = translate()(connect()(DetailsTableBase));
+const DetailsTable = injectIntl(connect()(DetailsTableBase));
 
 export { DetailsTable, DetailsTableProps };

--- a/src/pages/details/ocpDetails/detailsTableItem.tsx
+++ b/src/pages/details/ocpDetails/detailsTableItem.tsx
@@ -13,7 +13,7 @@ import { Cluster } from 'pages/details/components/cluster/cluster';
 import { HistoricalModal } from 'pages/details/components/historicalChart/historicalModal';
 import { Tag } from 'pages/details/components/tag/tag';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { getTestProps, testIds } from 'testIds';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
@@ -30,7 +30,7 @@ interface DetailsTableItemState {
   isHistoricalModalOpen: boolean;
 }
 
-type DetailsTableItemProps = DetailsTableItemOwnProps & InjectedTranslateProps;
+type DetailsTableItemProps = DetailsTableItemOwnProps & WrappedComponentProps;
 
 const reportPathsType = ReportPathsType.ocp;
 
@@ -56,7 +56,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
   };
 
   public render() {
-    const { item, groupBy, t } = this.props;
+    const { item, groupBy, intl } = this.props;
     const { isHistoricalModalOpen } = this.state;
 
     return (
@@ -70,7 +70,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 type={ButtonType.button}
                 variant={ButtonVariant.secondary}
               >
-                {t('ocp_details.historical.view_data')}
+                {intl.formatMessage({ id: 'ocp_details.historical.view_data' })}
               </Button>
             </div>
           </GridItem>
@@ -80,7 +80,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 <div style={styles.clusterContainer}>
                   <Form>
                     <FormGroup
-                      label={t('ocp_details.cluster_label')}
+                      label={intl.formatMessage({
+                        id: 'ocp_details.cluster_label',
+                      })}
                       fieldId="cluster-name"
                     >
                       <Cluster groupBy={groupBy} item={item} />
@@ -99,7 +101,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 <div style={styles.tagsContainer}>
                   <Form>
                     <FormGroup
-                      label={t('ocp_details.tags_label')}
+                      label={intl.formatMessage({
+                        id: 'ocp_details.tags_label',
+                      })}
                       fieldId="tags"
                     >
                       <Tag
@@ -134,6 +138,6 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
   }
 }
 
-const DetailsTableItem = translate()(connect()(DetailsTableItemBase));
+const DetailsTableItem = injectIntl(connect()(DetailsTableItemBase));
 
 export { DetailsTableItem, DetailsTableItemProps };

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -4,7 +4,7 @@ import { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -38,7 +38,7 @@ interface DetailsToolbarState {
 type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarStateProps &
   DetailsToolbarDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.ocp;
@@ -68,13 +68,22 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report, t } = this.props;
+    const { report, intl } = this.props;
 
     const options = [
-      { name: t('filter_by.values.cluster'), key: 'cluster' },
-      { name: t('filter_by.values.node'), key: 'node' },
-      { name: t('filter_by.values.project'), key: 'project' },
-      { name: t('filter_by.values.tag'), key: 'tag' },
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.cluster' }),
+        key: 'cluster',
+      },
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.node' }),
+        key: 'node',
+      },
+      {
+        name: intl.formatMessage({ id: 'filter_by.values.project' }),
+        key: 'project',
+      },
+      { name: intl.formatMessage({ id: 'filter_by.values.tag' }), key: 'tag' },
     ];
 
     return report && report.data && report.data.length
@@ -147,7 +156,7 @@ const mapDispatchToProps: DetailsToolbarDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const DetailsToolbar = translate()(
+const DetailsToolbar = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(DetailsToolbarBase)
 );
 

--- a/src/pages/details/ocpDetails/historicalChart.tsx
+++ b/src/pages/details/ocpDetails/historicalChart.tsx
@@ -15,7 +15,7 @@ import {
   styles,
 } from 'pages/details/components/historicalChart/historicalChart.styles';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -52,7 +52,7 @@ interface HistoricalChartDispatchProps {
 type HistoricalChartProps = HistoricalChartOwnProps &
   HistoricalChartStateProps &
   HistoricalChartDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const cpuReportType = ReportType.cpu;
 const costReportType = ReportType.cost;
@@ -109,7 +109,7 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
       previousCpuReportFetchStatus,
       previousMemoryReport,
       previousMemoryReportFetchStatus,
-      t,
+      intl,
     } = this.props;
 
     // Cost data
@@ -252,11 +252,20 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
               height={chartStyles.chartHeight}
               previousCostData={previousCostData}
               previousInfrastructureCostData={previousInfrastructureCostData}
-              title={t('ocp_details.historical.cost_title')}
-              xAxisLabel={t('ocp_details.historical.day_of_month_label')}
-              yAxisLabel={t('ocp_details.historical.cost_label', {
-                units: t(`units.${unitLookupKey(costUnits)}`),
+              title={intl.formatMessage({
+                id: 'ocp_details.historical.cost_title',
               })}
+              xAxisLabel={intl.formatMessage({
+                id: 'ocp_details.historical.day_of_month_label',
+              })}
+              yAxisLabel={intl.formatMessage(
+                { id: 'ocp_details.historical.cost_label' },
+                {
+                  units: intl.formatMessage({
+                    id: `units.${unitLookupKey(costUnits)}`,
+                  }),
+                }
+              )}
             />
           )}
         </div>
@@ -276,11 +285,20 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
               previousLimitData={previousCpuLimitData}
               previousRequestData={previousCpuRequestData}
               previousUsageData={previousCpuUsageData}
-              title={t('ocp_details.historical.cpu_title')}
-              xAxisLabel={t('ocp_details.historical.day_of_month_label')}
-              yAxisLabel={t('ocp_details.historical.cpu_label', {
-                units: t(`units.${unitLookupKey(cpuUnits)}`),
+              title={intl.formatMessage({
+                id: 'ocp_details.historical.cpu_title',
               })}
+              xAxisLabel={intl.formatMessage({
+                id: 'ocp_details.historical.day_of_month_label',
+              })}
+              yAxisLabel={intl.formatMessage(
+                { id: 'ocp_details.historical.cpu_label' },
+                {
+                  units: intl.formatMessage({
+                    id: `units.${unitLookupKey(cpuUnits)}`,
+                  }),
+                }
+              )}
             />
           )}
         </div>
@@ -300,11 +318,20 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
               previousLimitData={previousMemoryLimitData}
               previousRequestData={previousMemoryRequestData}
               previousUsageData={previousMemoryUsageData}
-              title={t('ocp_details.historical.memory_title')}
-              xAxisLabel={t('ocp_details.historical.day_of_month_label')}
-              yAxisLabel={t('ocp_details.historical.memory_label', {
-                units: t(`units.${unitLookupKey(memoryUnits)}`),
+              title={intl.formatMessage({
+                id: 'ocp_details.historical.memory_title',
               })}
+              xAxisLabel={intl.formatMessage({
+                id: 'ocp_details.historical.day_of_month_label',
+              })}
+              yAxisLabel={intl.formatMessage(
+                { id: 'ocp_details.historical.memory_label' },
+                {
+                  units: intl.formatMessage({
+                    id: `units.${unitLookupKey(memoryUnits)}`,
+                  }),
+                }
+              )}
             />
           )}
         </div>
@@ -412,7 +439,7 @@ const mapDispatchToProps: HistoricalChartDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const HistoricalChart = translate()(
+const HistoricalChart = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(HistoricalChartBase)
 );
 

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -16,7 +16,7 @@ import { LoadingState } from 'components/state/loadingState/loadingState';
 import { NoProvidersState } from 'components/state/noProvidersState/noProvidersState';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -54,7 +54,7 @@ interface OcpDetailsState {
   selectedItems: ComputedReportItem[];
 }
 
-type OcpDetailsOwnProps = RouteComponentProps<void> & InjectedTranslateProps;
+type OcpDetailsOwnProps = RouteComponentProps<void> & WrappedComponentProps;
 
 type OcpDetailsProps = OcpDetailsStateProps &
   OcpDetailsOwnProps &
@@ -498,6 +498,6 @@ const mapDispatchToProps: OcpDetailsDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-export default translate()(
+export default injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(OcpDetails)
 );

--- a/src/pages/details/ocpDetails/summary.tsx
+++ b/src/pages/details/ocpDetails/summary.tsx
@@ -13,7 +13,7 @@ import {
 import { styles } from 'pages/details/components/summary/summary.styles';
 import { SummaryModal } from 'pages/details/components/summary/summaryModal';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -46,7 +46,7 @@ interface SummaryDispatchProps {
 type SummaryProps = SummaryOwnProps &
   SummaryStateProps &
   SummaryDispatchProps &
-  InjectedTranslateProps;
+  WrappedComponentProps;
 
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.ocp;
@@ -79,10 +79,10 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   private getSummary = () => {
-    const { report, reportFetchStatus, t } = this.props;
+    const { report, reportFetchStatus, intl } = this.props;
     return (
       <>
-        {t('group_by.details', { groupBy: 'project' })}
+        {intl.formatMessage({ id: 'group_by.details' }, { groupBy: 'project' })}
         <div style={styles.summary}>
           <ReportSummaryItems
             idKey={'project' as any}
@@ -110,7 +110,7 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   private getViewAll = () => {
-    const { groupBy, item, t } = this.props;
+    const { groupBy, item, intl } = this.props;
     const { isBulletChartModalOpen } = this.state;
 
     const currentTab = 'project';
@@ -131,7 +131,10 @@ class SummaryBase extends React.Component<SummaryProps> {
             type={ButtonType.button}
             variant={ButtonVariant.link}
           >
-            {t('details.view_all', { groupBy: currentTab })}
+            {intl.formatMessage(
+              { id: 'details.view_all' },
+              { groupBy: currentTab }
+            )}
           </Button>
           <SummaryModal
             groupBy={currentTab}
@@ -215,7 +218,7 @@ const mapDispatchToProps: SummaryDispatchProps = {
   fetchReport: reportActions.fetchReport,
 };
 
-const Summary = translate()(
+const Summary = injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(SummaryBase)
 );
 

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -22,7 +22,7 @@ import OcpDashboard from 'pages/dashboard/ocpDashboard/ocpDashboard';
 import OcpSupplementaryDashboard from 'pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboard';
 import OcpUsageDashboard from 'pages/dashboard/ocpUsageDashboard/ocpUsageDashboard';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -63,7 +63,7 @@ export const getIdKeyForTab = (tab: OverviewTab) => {
   }
 };
 
-type OverviewOwnProps = RouteComponentProps<{}> & InjectedTranslateProps;
+type OverviewOwnProps = RouteComponentProps<{}> & WrappedComponentProps;
 
 interface OverviewStateProps {
   awsProviders: Providers;
@@ -368,12 +368,12 @@ class OverviewBase extends React.Component<OverviewProps> {
   };
 
   private getTabTitle = (tab: OverviewTab) => {
-    const { t } = this.props;
+    const { intl } = this.props;
 
     if (tab === OverviewTab.infrastructure) {
-      return t('overview.infrastructure');
+      return intl.formatMessage({ id: 'overview.infrastructure' });
     } else if (tab === OverviewTab.ocp) {
-      return t('overview.ocp');
+      return intl.formatMessage({ id: 'overview.ocp' });
     }
   };
 
@@ -441,7 +441,7 @@ class OverviewBase extends React.Component<OverviewProps> {
       azureProvidersFetchStatus,
       ocpProvidersError,
       ocpProvidersFetchStatus,
-      t,
+      intl,
     } = this.props;
     const availableTabs = this.getAvailableTabs();
     const error = awsProvidersError || azureProvidersError || ocpProvidersError;
@@ -470,27 +470,39 @@ class OverviewBase extends React.Component<OverviewProps> {
         >
           <header className="pf-u-display-flex pf-u-justify-content-space-between pf-u-align-items-center">
             <Title size={TitleSize['2xl']}>
-              {t('overview.title')}
+              {intl.formatMessage({ id: 'overview.title' })}
               {Boolean(showTabs) && (
                 <span style={styles.infoIcon}>
                   <Popover
-                    aria-label="t('ocp_details.supplementary_aria_label')"
+                    aria-label="intl.formatMessage({ id: 'ocp_details.supplementary_aria_label' })"
                     enableFlip
                     bodyContent={
                       <>
                         <p style={styles.infoTitle}>
-                          {t('overview.ocp_cloud')}
+                          {intl.formatMessage({ id: 'overview.ocp_cloud' })}
                         </p>
-                        <p>{t('overview.ocp_cloud_desc')}</p>
+                        <p>
+                          {intl.formatMessage({
+                            id: 'overview.ocp_cloud_desc',
+                          })}
+                        </p>
                         <br />
-                        <p style={styles.infoTitle}>{t('overview.ocp')}</p>
-                        <p>{t('overview.ocp_desc')}</p>
+                        <p style={styles.infoTitle}>
+                          {intl.formatMessage({ id: 'overview.ocp' })}
+                        </p>
+                        <p>{intl.formatMessage({ id: 'overview.ocp_desc' })}</p>
                         <br />
-                        <p style={styles.infoTitle}>{t('overview.aws')}</p>
-                        <p>{t('overview.aws_desc')}</p>
+                        <p style={styles.infoTitle}>
+                          {intl.formatMessage({ id: 'overview.aws' })}
+                        </p>
+                        <p>{intl.formatMessage({ id: 'overview.aws_desc' })}</p>
                         <br />
-                        <p style={styles.infoTitle}>{t('overview.azure')}</p>
-                        <p>{t('overview.azure_desc')}</p>
+                        <p style={styles.infoTitle}>
+                          {intl.formatMessage({ id: 'overview.azure' })}
+                        </p>
+                        <p>
+                          {intl.formatMessage({ id: 'overview.azure_desc' })}
+                        </p>
                       </>
                     }
                   >
@@ -600,6 +612,6 @@ const mapStateToProps = createMapStateToProps<
   };
 });
 
-const Overview = translate()(connect(mapStateToProps)(OverviewBase));
+const Overview = injectIntl(connect(mapStateToProps)(OverviewBase));
 
 export default Overview;

--- a/src/pages/overview/perspective.tsx
+++ b/src/pages/overview/perspective.tsx
@@ -1,6 +1,6 @@
 import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { styles } from './perspective.styles';
 
 interface PerspectiveOwnProps {
@@ -16,7 +16,7 @@ interface PerspectiveState {
   isPerspectiveOpen: boolean;
 }
 
-type PerspectiveProps = PerspectiveOwnProps & InjectedTranslateProps;
+type PerspectiveProps = PerspectiveOwnProps & WrappedComponentProps;
 
 class PerspectiveBase extends React.Component<PerspectiveProps> {
   protected defaultState: PerspectiveState = {
@@ -25,7 +25,7 @@ class PerspectiveBase extends React.Component<PerspectiveProps> {
   public state: PerspectiveState = { ...this.defaultState };
 
   private getDropDownItems = () => {
-    const { options, t } = this.props;
+    const { options, intl } = this.props;
 
     return options.map(option => (
       <DropdownItem
@@ -33,18 +33,18 @@ class PerspectiveBase extends React.Component<PerspectiveProps> {
         key={option.value}
         onClick={() => this.handleClick(option.value)}
       >
-        {t(option.label)}
+        {intl.formatMessage({ id: option.label })}
       </DropdownItem>
     ));
   };
 
   private getCurrentLabel = () => {
-    const { currentItem, options, t } = this.props;
+    const { currentItem, options, intl } = this.props;
 
     let label = '';
     for (const option of options) {
       if (currentItem === option.value) {
-        label = t(option.label);
+        label = intl.formatMessage({ id: option.label });
         break;
       }
     }
@@ -71,14 +71,14 @@ class PerspectiveBase extends React.Component<PerspectiveProps> {
   };
 
   public render() {
-    const { t } = this.props;
+    const { intl } = this.props;
     const { isPerspectiveOpen } = this.state;
     const dropdownItems = this.getDropDownItems();
 
     return (
       <div style={styles.perspectiveSelector}>
         <label style={styles.perspectiveLabel}>
-          {t('overview.perspective.label')}
+          {intl.formatMessage({ id: 'overview.perspective.label' })}
         </label>
         <Dropdown
           onSelect={this.handleSelect}
@@ -95,6 +95,6 @@ class PerspectiveBase extends React.Component<PerspectiveProps> {
   }
 }
 
-const Perspective = translate()(PerspectiveBase);
+const Perspective = injectIntl(PerspectiveBase);
 
 export { Perspective };

--- a/src/store/rbac/actions.ts
+++ b/src/store/rbac/actions.ts
@@ -1,8 +1,8 @@
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { getRBAC, RBAC } from 'api/rbac';
-import i18next from 'i18next';
 import { Dispatch } from 'react-redux';
 import { createAsyncAction } from 'typesafe-actions';
+import { t } from '../../components/i18nProvider';
 
 export const {
   request: fetchRbacRequest,
@@ -24,8 +24,8 @@ export const fetchRbac = () => {
       .catch(err => {
         dispatch(
           addNotification({
-            title: i18next.t('rbac.error_title'),
-            description: i18next.t('rbac.error_description'),
+            title: t('rbac.error_title'),
+            description: t('rbac.error_description'),
             variant: 'danger',
             dismissable: true,
           })

--- a/src/utils/dateRange.ts
+++ b/src/utils/dateRange.ts
@@ -2,7 +2,7 @@ import formatDate from 'date-fns/format';
 import getDate from 'date-fns/get_date';
 import getMonth from 'date-fns/get_month';
 import startOfMonth from 'date-fns/start_of_month';
-import i18next from 'i18next';
+import { t } from '../components/i18nProvider';
 
 export function getNoDataForDateRangeString(
   key: string = 'no_data_for_date',
@@ -17,7 +17,7 @@ export function getNoDataForDateRangeString(
   const endDate = formatDate(today, 'D');
   const startDate = formatDate(startOfMonth(today), 'D');
 
-  return i18next.t(key, {
+  return t(key, {
     count: getDate(today),
     endDate,
     month,
@@ -39,7 +39,7 @@ export function getForDateRangeString(
   const endDate = formatDate(today, 'D');
   const startDate = formatDate(startOfMonth(today), 'D');
 
-  return i18next.t(key, {
+  return t(key, {
     count: getDate(today),
     endDate,
     month,
@@ -54,7 +54,7 @@ export function getSinceDateRangeString(key: string = 'since_date') {
   const endDate = formatDate(today, 'D');
   const startDate = formatDate(startOfMonth(today), 'D');
 
-  return i18next.t(key, {
+  return t(key, {
     count: getDate(today),
     endDate,
     month,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "noUnusedLocals": true,
+    "resolveJsonModule": true,
     "lib": [
       "dom",
       "es2017"

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,6 +193,39 @@
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
 
+"@formatjs/intl-displaynames@^1.2.9":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-displaynames/-/intl-displaynames-1.2.9.tgz#be30523a91b3f5102fcd1754679073be6f8ee545"
+  integrity sha512-XQF2rHM0DaxShGtr03wt1eWBye0t8WDSvXfpby0ewSPs0n0uUjQOkyouTqFUderNuXV3aY8vpxq+pnHEkW/VNg==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.5"
+
+"@formatjs/intl-listformat@^1.4.7":
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-1.4.7.tgz#6529663d535ba24c1a33b26bdb4f6e0c1616466e"
+  integrity sha512-g0oXgMYhe7CFdH8jEUz64K7sLjo2p8tQAuGGXjcibODCsJvBV+YrC69WGmzQpJPCoeK5kxG7PXQRUO1Sr6NEfA==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.5"
+
+"@formatjs/intl-relativetimeformat@^4.5.15":
+  version "4.5.15"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.15.tgz#1e31cdfc334603e380032745398186265ecc6049"
+  integrity sha512-DVtiHWMpwsuqPBtszOTmhv6m94RuiPN6/ltWCm6tul/lIFKotoJOvo1CkytfzWJ3ypjnfbYsfPRhvCCQTqVarQ==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.5"
+
+"@formatjs/intl-unified-numberformat@^3.3.6":
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.6.tgz#ab69818f7568894023cb31fdb5b5c7eed62c6537"
+  integrity sha512-VQYswh9Pxf4kN6FQvKprAQwSJrF93eJstCDPM1HIt3c3O6NqPFWNWhZ91PLTppOV11rLYsFK11ZxiGbnLNiPTg==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.5"
+
+"@formatjs/intl-utils@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.2.5.tgz#eaafd94df3d102ee13e54e80f992a33868a6b1e8"
+  integrity sha512-p7gcmazKROteL4IECCp03Qrs790fZ8tbemUAjQu0+K0AaAlK49rI1SIFFq3LzDUAqXIshV95JJhRe/yXxkal5g==
+
 "@fortawesome/fontawesome-common-types@^0.2.0", "@fortawesome/fontawesome-common-types@^0.2.27":
   version "0.2.27"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.27.tgz#19706345859fc46adf3684ed01d11b40903b87e9"
@@ -456,6 +489,14 @@
   version "4.7.5"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.5.tgz#527d20ef68571a4af02ed74350164e7a67544860"
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/i18next-xhr-backend@1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@types/i18next-xhr-backend/-/i18next-xhr-backend-1.4.1.tgz#9da90a5e3086014d09c612b05e11a77170d30277"
@@ -469,6 +510,11 @@
 "@types/i18next@8.4.4":
   version "8.4.4"
   resolved "https://registry.yarnpkg.com/@types/i18next/-/i18next-8.4.4.tgz#76591ab5974b65910e44b8860202d4f544f39b9d"
+
+"@types/invariant@^2.2.31":
+  version "2.2.32"
+  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.32.tgz#cf523a609062564e36e7a7dadb5089ed87da6382"
+  integrity sha512-WjY4WVFaehHv+TOgm+dS3UI559NvsPGFz/C0nIo7KOOdC+HeC7Y3/yLzdJYQ3+oFQaTXrOVm7cNtIgMataIDVg==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
@@ -4438,7 +4484,7 @@ hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
-hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   dependencies:
@@ -4816,6 +4862,26 @@ internal-ip@1.2.0:
 interpret@^1.0.0, interpret@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
+
+intl-format-cache@^4.2.27:
+  version "4.2.27"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.2.27.tgz#d25fa83639913aec10ca5a8f9e3b6449bb0eacf2"
+  integrity sha512-blHXX9qBp8H6fGhQc0jHGh7j97HF0megj4rIB878iazMBdFk/tR7b3av0PJxE72TP8MycLFpeXW9vLY5cBmF4A==
+
+intl-messageformat-parser@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-5.0.3.tgz#f281a9446b896f24a8f00ab9415019a28d59ca57"
+  integrity sha512-u2goKAXOJLkiHBy0zB3HTMuHhWDNFYUyPVevvUeSuacGFqe04jvyvYIJIoVgHD3RYhFJ9T+0UgT0dNbu+51TEw==
+  dependencies:
+    "@formatjs/intl-unified-numberformat" "^3.3.6"
+
+intl-messageformat@^8.3.10:
+  version "8.3.10"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-8.3.10.tgz#4346cf6f3a525fb69f4df2f46e804bf855ea796a"
+  integrity sha512-0CWciO3DniD8WH0FDkxLlFGAHAYrkeGT2T5sRkrmmg1xFJV64MzgmJU0AiBHbdy/2DGyOxZlba8v6xhrHAygNQ==
+  dependencies:
+    intl-format-cache "^4.2.27"
+    intl-messageformat-parser "^5.0.3"
 
 into-stream@^3.1.0:
   version "3.1.0"
@@ -7604,6 +7670,24 @@ react-i18next@7.13.0:
     html-parse-stringify2 "2.0.1"
     prop-types "^15.6.0"
 
+react-intl@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-4.5.3.tgz#d24774fa20aeb1049c5d8cb04f1c8d9da0efb6a8"
+  integrity sha512-qx7R7bRdmmoBbHBaQCTWIui5KcMOpUWZwe7oF83x1oLf5KJ5zm4Qt9XCGF7Ki4JbYTNuUiz7QUc4IPy0HFoMGg==
+  dependencies:
+    "@formatjs/intl-displaynames" "^1.2.9"
+    "@formatjs/intl-listformat" "^1.4.7"
+    "@formatjs/intl-relativetimeformat" "^4.5.15"
+    "@formatjs/intl-unified-numberformat" "^3.3.6"
+    "@formatjs/intl-utils" "^2.2.5"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/invariant" "^2.2.31"
+    hoist-non-react-statics "^3.3.2"
+    intl-format-cache "^4.2.27"
+    intl-messageformat "^8.3.10"
+    intl-messageformat-parser "^5.0.3"
+    shallow-equal "^1.2.1"
+
 react-is@^16.3.2, react-is@^16.6.1, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
@@ -8296,6 +8380,11 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallow-equal@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
+  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 shallowequal@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
Koku uses i18next. An investigation was done to see what it would take to convert it over to react-intl, and to explore further what the shortcomings of react-intl are.
> In summary, I would recommend sticking with i18next.

The PR (WIP) is here [https://github.com/jschuler/koku-ui/pull/1](https://github.com/jschuler/koku-ui/pull/1)

Shortcomings of react-intl:
- Prefers flat json data, i.e
```
// works with this
{
  "hello": "hello",
  "world": "world"
}
// but not with nested data
{
  "welcome": {
    "hello": "hello",
    "world": "world"
  }
}
```
Koku makes extensive use of nested data, i.e. by calling `t('welcome.hello')`
To workaround this, additional logic has to be added to flatten the json like it was done here [https://github.com/jschuler/koku-ui/pull/1/files#diff-0417c9525c1207ae1b79720843d58550R8](https://github.com/jschuler/koku-ui/pull/1/files#diff-0417c9525c1207ae1b79720843d58550R8)

- Little more work to use outside of components (e.g. in utility functions)
To use it outside of components, need to create an intl instance and then use that, example: [https://formatjs.io/docs/react-intl/api#createintl](https://formatjs.io/docs/react-intl/api#createintl)

- simple function calls to translate messages require an id to be passed, e.g.
```
// does not work with
t('hello.world')
// wants
t({ id: 'hello.world' })
```

- No built-in mechanism to load messages from another web-server
- Does not support referencing keys in values in message json files. Koku uses this feature quite a bit in the json file:
[https://www.i18next.com/translation-function/nesting#basic](https://www.i18next.com/translation-function/nesting#basic)
For example:
```
"widget_subtitle": "{{startDate}} $t(months.{{month}})",
```
Using `$t` in a value lets you reference other keys. This cannot be done in react-intl.

### Reasons for i18next
-   Splitting translations into multiple files. Only load translations needed.
    
-   There are plugins to **detect languages** for most environments (browser, native, server). This enables to set priority of where to detect and even enables to cache set languages over requests / visits.
    
-   There are endless plugins to **load translation** from server, filesystem, ... these backends also assert that loading gets retried on failure, or that a file does not get loaded twice and callbacks of success are only called once. Those backends can even provide an additional layer for **local caching** eg. in localStorage.
    
-   Options what to load and how to fallback depending on language.
    
-   Support for [objects and arrays](https://www.i18next.com/translation-function/objects-and-arrays)
    
-   Full control over management of the translations stored.
    
-   Rich system of events to react on changes important to your application.
    
-   Freedom of [i18n formats](https://www.i18next.com/overview/plugins-and-utils#i-18-n-formats) - prefer ICU? Just use i18next-icu plugin.